### PR TITLE
项目改名为 tryzealot

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,6 +1,6 @@
 newIssueWelcomeComment: >
   感谢你提交的问题或反馈，我会在有时间的时候回复在此期间你可以看看
-  [之前被解决的反馈](https://github.com/getzealot/zealot/issues?q=is%3Aissue+is%3Aclosed)说不定有你需要的答案。
+  [之前被解决的反馈](https://github.com/tryzealot/zealot/issues?q=is%3Aissue+is%3Aclosed)说不定有你需要的答案。
 
 newPRWelcomeComment: >
   感谢你提交的问题或反馈，我会在有时间的时候来审查代码。

--- a/.github/workflows/publish_nighty.yml
+++ b/.github/workflows/publish_nighty.yml
@@ -25,7 +25,7 @@ jobs:
         BUILD_DATE: ${{ steps.date.outputs.date }}
         TAG: nightly
       with:
-        name: icyleafcn/zealot:${{ env.TAG }}
+        name: tryzealot/zealot:${{ env.TAG }}
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         buildargs: BUILD_DATE,VCS_REF,TAG,REPLACE_CHINA_MIRROR
@@ -34,7 +34,7 @@ jobs:
       env:
         DOCKERHUB_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKERHUB_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        DOCKERHUB_REPOSITORY: icyleafcn/zealot
+        DOCKERHUB_REPOSITORY: tryzealot/zealot
     - name: Trigger Microbadger update
       uses: wei/curl@master
       with:

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -23,7 +23,7 @@ jobs:
         BUILD_DATE: ${{ steps.date.outputs.date }}
         TAG: ${{ steps.version.outputs.tag }}
       with:
-        name: icyleafcn/zealot:${{ env.TAG }}
+        name: tryzealot/zealot:${{ env.TAG }}
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         buildargs: BUILD_DATE,VCS_REF,TAG,REPLACE_CHINA_MIRROR
@@ -32,7 +32,7 @@ jobs:
       env:
         DOCKERHUB_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKERHUB_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        DOCKERHUB_REPOSITORY: icyleafcn/zealot
+        DOCKERHUB_REPOSITORY: tryzealot/zealot
     - name: Trigger Microbadger update
       uses: wei/curl@master
       with:

--- a/.github/workflows/test_docker_build.yml
+++ b/.github/workflows/test_docker_build.yml
@@ -13,6 +13,6 @@ jobs:
         BUILD_DATE: ${{ steps.date.outputs.date }}
         TAG: pr-test
       with:
-        name: icyleafcn/zealot:${{ env.TAG }}
+        name: tryzealot/zealot:${{ env.TAG }}
         no_push: true
         buildargs: BUILD_DATE,VCS_REF,TAG,REPLACE_CHINA_MIRROR

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,7 @@ LABEL im.ews.zealot.build-date=$BUILD_DATE \
       im.ews.zealot.name="Zealot" \
       im.ews.zealot.description="Over The Air Server for deployment of Android and iOS apps" \
       im.ews.zealot.url="https://zealot.ews.im/" \
-      im.ews.zealot.vcs-url="https://github.com/getzealot/zealot" \
+      im.ews.zealot.vcs-url="https://github.com/tryzealot/zealot" \
       im.ews.zealot.maintaner="icyleaf <icyleaf.cn@gmail.com>"
 
 ENV TZ="Asia/Shanghai" \

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Zealot
 
-[![GitHub release](https://img.shields.io/github/v/release/getzealot/zealot?include_prereleases)](https://github.com/getzealot/zealot/blob/develop/CHANGELOG.md)
-[![Docker Pulls](https://img.shields.io/docker/pulls/icyleafcn/zealot.svg)](https://hub.docker.com/r/icyleafcn/zealot/)
-[![Maintainability](https://codeclimate.com/github/getzealot/zealot/badges/gpa.svg)](https://codeclimate.com/github/getzealot/zealot)
+[![GitHub release](https://img.shields.io/github/v/release/tryzealot/zealot?include_prereleases)](https://github.com/tryzealot/zealot/blob/develop/CHANGELOG.md)
+[![Docker Pulls](https://img.shields.io/docker/pulls/tryzealot/zealot.svg)](https://hub.docker.com/r/tryzealot/zealot/)
+[![Maintainability](https://codeclimate.com/github/tryzealot/zealot/badges/gpa.svg)](https://codeclimate.com/github/tryzealot/zealot)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/bcff7d9de5ba48528bc80aa01bd525c6)](https://www.codacy.com/manual/icyleaf/zealot)
-[![License](https://img.shields.io/github/license/getzealot/zealot)](LICENSE)
+[![License](https://img.shields.io/github/license/tryzealot/zealot)](LICENSE)
 
 移动应用上传竟然如此简单、解放开发打包的烦恼，轻松放权给测试、产品、运营等使用 App 的人员，提供丰富组件库，打包流程一键上传，iOS 和 Android 轻松接入，深度与 Jenkins 和 Gitlab 集成。
 
@@ -18,7 +18,7 @@
 - [x] 支持获取 iOS 设备 UDID 及显示支持安装的应用
 - [x] 支持 OAuth 认证登录（目前以接入 Google，LDAP）
 - [x] 提供检查新版本和安装服务的 iOS 和 Android 组件
-- [x] 提供 fastlane 插件 [zealot](https://github.com/getzealot/fastlane-plugin-zealot) 提供上传应用和调试文件服务
+- [x] 提供 fastlane 插件 [zealot](https://github.com/tryzealot/fastlane-plugin-zealot) 提供上传应用和调试文件服务
 - [x] 可接入 Gitlab 服务直接挂钩源码管理
 - [ ] 可接入 Jenkins 服务实现远程构建
 - [x] 支持丰富的 REST APIs
@@ -26,8 +26,8 @@
 
 ## 最新版本
 
-- [x] 测试版本 - develop - `icyleafcn/zealot:nightly` - 基于 develop 分支每次提交构建的版本
-- [ ] 稳定版本 - v4.0.0 - `icyleafcn/zealot:latest` - 还在研发测试中，尚未发布。
+- [x] 测试版本 - develop - `tryzealot/zealot:nightly` - 基于 develop 分支每次提交构建的版本
+- [ ] 稳定版本 - 4.0.0 - `tryzealot/zealot:latest` - 还在研发测试中，尚未发布。
 
 ## 演示
 
@@ -40,7 +40,7 @@
 ## 快速上手
 
 ```
-$ git clone https://github.com/getzealot/zealot-docker.git
+$ git clone https://github.com/tryzealot/zealot-docker.git
 $ cd zealot-docker
 $ ./deploy
 ```
@@ -58,9 +58,9 @@ https://zealot.ews.im
 
 对 Zealot 有疑问或者建议，发个问题告知下
 
-https://github.com/getzealot/zealot/issues/new
+https://github.com/tryzealot/zealot/issues/new
 
 
-[fastlan-plugin-link]: https://github.com/getzealot/fastlane-plugin-zealot
-[ios-sdk-link]: https://github.com/getzealot/zealot-ios
-[android-sdk-link]: https://github.com/getzealot/zealot-android
+[fastlan-plugin-link]: https://github.com/tryzealot/fastlane-plugin-zealot
+[ios-sdk-link]: https://github.com/tryzealot/zealot-ios
+[android-sdk-link]: https://github.com/tryzealot/zealot-android

--- a/app/controllers/admin/system_info_controller.rb
+++ b/app/controllers/admin/system_info_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Admin::SystemInfoController < ApplicationController
-  VERSION_CHECK_URL = 'https://api.github.com/repos/getzealot/zealot/releases/latest'
+  VERSION_CHECK_URL = 'https://api.github.com/repos/tryzealot/zealot/releases/latest'
 
   EXCLUDED_MOUNT_OPTIONS = [
     'nobrowse',

--- a/app/views/layouts/_footer.html.slim
+++ b/app/views/layouts/_footer.html.slim
@@ -4,6 +4,6 @@ footer.main-footer
     = " #{Setting.version}"
   strong
     | Copyright &copy; 2015-2019&nbsp
-    a href="https://github.com/getzealot/zealot" Zealot
+    a href="https://github.com/tryzealot/zealot" Zealot
     | .
   |  All rights reserved.

--- a/lib/backup/manager.rb
+++ b/lib/backup/manager.rb
@@ -160,7 +160,7 @@ module Backup
           logger.puts
           logger.puts "Hint:"
           logger.puts "  1. git checkout v#{settings[:zealot_version]}"
-          logger.puts "  2. docker pull icyleafcn/zealot:#{settings[:zealot_version]}"
+          logger.puts "  2. docker pull tryzealot/zealot:#{settings[:zealot_version]}"
           exit 1
         end
       end

--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -2,6 +2,6 @@
 
 namespace :docker do
   task build: :environment do
-    system('docker build -t icyleafcn/zealot:dev .')
+    system('docker build -t tryzealot/zealot:dev .')
   end
 end


### PR DESCRIPTION
涉及两个部分的变更：

Github 项目地址

```diff
- https://github.com/getzealot/zealot
+ https://github.com/tryzealot/zealot
```

Docker hub 镜像地址

```diff
- icyleafcn/zealot
+ tryzealot/zealot
```