### PR TITLE
Docker 改用 caddy 作为默认的 web 服务

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,7 @@ RUN bundle config --global frozen 1 && \
       --jobs `expr $(cat /proc/cpuinfo | grep -c "cpu cores") - 1` --retry 3
 
 COPY . $APP_ROOT
-RUN SECRET_TOKEN=precompile_placeholder bin/rails assets:precompile && \
-    cp -r public/ new_public/
+RUN SECRET_TOKEN=precompile_placeholder bin/rails assets:precompile
 
 # Remove folders not needed in resulting image
 RUN rm -rf docker node_modules tmp/cache spec .browserslistrc babel.config.js \
@@ -70,7 +69,7 @@ ARG RUBYGEMS_SOURCE="https://gems.ruby-china.com/"
 ARG PACKAGES="tzdata curl logrotate imagemagick imagemagick-dev postgresql-dev postgresql-client openssl openssl-dev caddy"
 ARG RUBY_GEMS="bundler"
 ARG APP_ROOT=/app
-ARG S6_OVERLAY_VERSION="2.1.0.1"
+ARG S6_OVERLAY_VERSION="2.2.0.3"
 
 LABEL org.opencontainers.image.title="Zealot" \
       org.opencontainers.image.description="Over The Air Server for deployment of Android and iOS apps" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ ARG REPLACE_CHINA_MIRROR="true"
 ARG ORIGINAL_REPO_URL="dl-cdn.alpinelinux.org"
 ARG MIRROR_REPO_URL="mirrors.ustc.edu.cn"
 ARG RUBYGEMS_SOURCE="https://gems.ruby-china.com/"
-ARG PACKAGES="tzdata curl logrotate imagemagick imagemagick-dev postgresql-dev postgresql-client openssl openssl-dev"
+ARG PACKAGES="tzdata curl logrotate imagemagick imagemagick-dev postgresql-dev postgresql-client openssl openssl-dev caddy"
 ARG RUBY_GEMS="bundler"
 ARG APP_ROOT=/app
 ARG S6_OVERLAY_VERSION="2.1.0.1"
@@ -106,6 +106,8 @@ COPY --from=builder $APP_ROOT $APP_ROOT
 
 RUN ln -s /app/bin/rails /usr/local/bin/
 
-EXPOSE 3000
+EXPOSE 80
+
+VOLUME [ "/app/public/uploads", "/app/public/backup" ]
 
 ENTRYPOINT ["/init"]

--- a/docker/rootfs/etc/Caddyfile
+++ b/docker/rootfs/etc/Caddyfile
@@ -1,0 +1,27 @@
+:80
+
+root * /app/public
+encode zstd gzip
+file_server
+log
+
+@notStatic {
+  not file
+}
+
+reverse_proxy @notStatic {
+  to localhost:3000
+  @accel header X-Accel-Redirect *
+  handle_response @accel {
+    root    * /app/public
+    rewrite   {http.reverse_proxy.header.X-Accel-Redirect}
+    file_server
+  }
+
+  @error status 500 502 503
+  handle_response @error {
+    root    * /app/public
+    rewrite * /500.html
+    file_server
+  }
+}

--- a/docker/rootfs/etc/Caddyfile
+++ b/docker/rootfs/etc/Caddyfile
@@ -5,12 +5,19 @@ encode zstd gzip
 file_server
 log
 
-@notStatic {
+@zealot {
+  # # websockets
+  # header Connection *Upgrade*
+  # header Upgrade websocket
+
+  # static files
   not file
 }
 
-reverse_proxy @notStatic {
+# Docoument: https://caddyserver.com/docs/caddyfile/directives/reverse_proxy
+reverse_proxy @zealot {
   to localhost:3000
+
   @accel header X-Accel-Redirect *
   handle_response @accel {
     root    * /app/public

--- a/docker/rootfs/etc/cont-init.d/20-init-zealot
+++ b/docker/rootfs/etc/cont-init.d/20-init-zealot
@@ -5,21 +5,3 @@ cd /app
 # Clear pid if unexpected exception exit
 rm -f tmp/pids/.pid
 mkdir -p tmp/pids tmp/cache tmp/uploads tmp/sockets log
-
-# Updating assets
-if [ -d "new_public" ]; then
-  echo "Zealot updating public ..."
-  for x in public/*; do
-    if [ -z $(echo "$x" | grep uploads) ]; then
-      rm -rf "$x" > /dev/null
-    fi
-  done
-
-  for x in new_public/*; do
-    if [ -z $(echo "$x" | grep uploads) ]; then
-      mv "$x" "public"
-    fi
-  done
-
-  rm -rf new_public
-fi

--- a/docker/rootfs/etc/cont-init.d/25-upgrade-zealot
+++ b/docker/rootfs/etc/cont-init.d/25-upgrade-zealot
@@ -1,4 +1,10 @@
 #!/usr/bin/with-contenv sh
 
+echo "**************************************************"
+echo " WARNING: Using zealot-uploads and zealot-backups "
+echo "          instead of zealot-data volume, detail:  "
+echo "          https://git.io/JR0Gw                    "
+echo "**************************************************"
+
 cd /app && ./bin/rails zealot:upgrade
 exit 0

--- a/docker/rootfs/etc/services.d/caddy/run
+++ b/docker/rootfs/etc/services.d/caddy/run
@@ -1,0 +1,4 @@
+#!/usr/bin/with-contenv sh
+
+echo "Starting Caddy"
+/usr/sbin/caddy run -config /etc/Caddyfile  | tee /app/log/caddy.log


### PR DESCRIPTION
鉴于使用 s6-overlay 启动的优势可以把一些服务并行放到镜像里面，作为 rails 直接崩掉会影响显示的同时，后续在做热重启的时候可以利用反代服务器再做一次防御和显示处理。

## 目的

- 使用 Caddy 作为 puma 的反代服务器
- 静态文件全部交由 caddy 处理，rails 不再托管来加速 zealot 更快的启动和响应

## 重大变更

- 对外暴露的端口从 `3000` 变为 `80`
- volume 建议从 `/app/public` 分拆为 `/app/public/uploads` 和 `/app/public/backup` 两个路径做数据持久化。**如果还是继续使用之前的持久化将会出现更新镜像版本后但资源不会更新进而影响正常服务的使用**

## 配套动作

- [ ] 修改 zealot-docker 的配置脚本
