### PR TITLE
set ZEALOT_KEEP_UPLOADS=true

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -57,7 +57,7 @@ class Setting < RailsSettings::Base
 
   # 上传文件保留策略
   scope :limits do
-    field :keep_uploads, default: (ENV['ZEALOT_KEEP_UPLOADS'] || 'false'), type: :boolean, readonly: true
+    field :keep_uploads, default: (ENV['ZEALOT_KEEP_UPLOADS'] || 'true'), type: :boolean, readonly: true
   end
 
   # 第三方登录


### PR DESCRIPTION
不可否认的是，能够有一个自动的上传文件保留策略是好事。 但是对于平滑升级的用户来说，尤其是期待zealot的新功能而迫不及待的升级的用户，默认关闭保留策略太糟糕了。

即使从逻辑上说，well如果每一个人能够谨慎的，阅读详细新版本的变更，以及再次阅读部署文档的差异，这些问题不会遇到。
但是即使有那么一个用户遇到了这个问题，删除策略是不可逆转的，这会带来不可估计的时间成本的损失。

因此，我认为希望可以把默认的文件上传策略设置成true，也就是，在早期版本没有自动清理策略，也就没有环境变量配置的情况下，升级到新版本不会有破坏性的改动，而新的功能应该可以通过手动开启，以免造成影响