### PR TITLE
演示模式支持显示一些密钥类的配置但会从安全层面做限制

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -50,6 +50,10 @@ class Admin::SettingsController < ApplicationController
   end
 
   def verify_editable_setting
-    raise Pundit::NotAuthorizedError, t('admin.settings.no_editable_key') if @setting.readonly? === true
+    readonly = @setting.readonly? === true
+    demo_guest_with_secure_key = @setting.value.is_a?(Hash) && helpers.secure_key?(@setting.value)
+    if readonly || demo_guest_with_secure_key
+      raise Pundit::NotAuthorizedError.new({ query: :edit, record: @setting})
+    end
   end
 end

--- a/app/controllers/admin/system_info_controller.rb
+++ b/app/controllers/admin/system_info_controller.rb
@@ -79,9 +79,7 @@ class Admin::SystemInfoController < ApplicationController
   end
 
   def set_env
-    @env = ENV.each_with_object({}) do |(key, value), obj|
-      obj[key] = secure_key?(key) ? filtered_token(value) : value
-    end.sort
+    @env = ENV.sort
   end
 
   def set_gems
@@ -163,26 +161,6 @@ class Admin::SystemInfoController < ApplicationController
     }
   rescue
     @diskspace = nil
-  end
-
-  def secure_key?(key)
-    Rails.application
-         .config
-         .filter_parameters
-         .select { |p| key.downcase.include?(p.to_s) }
-         .size
-         .positive?
-  end
-
-  def filtered_token(chars)
-    chars = chars.to_s
-    return '*' * chars.size if chars.size < 4
-
-    average = chars.size / 4
-    prefix = chars[0..average - 1]
-    hidden = '*' * (average * 2)
-    suffix = chars[(prefix.size + average * 2)..-1]
-    "#{prefix}#{hidden}#{suffix}"
   end
 
   def percent(value, n)

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module AdminHelper
+  def pretty_json(data)
+    new_data = data.each_with_object({}) do |(key, value), obj|
+                 obj[key] = secure_value(key, value)
+               end
+
+    JSON.pretty_generate(new_data)
+  end
+
+  def secure_key?(data)
+    demo_mode? && data.keys.select {|k| secure?(k) }.any?
+  end
+
+  def secure_value(key, value)
+    (secure?(key) && demo_mode?) ? filtered_token(value) : value
+  end
+
+  private
+
+  def secure?(key)
+    Rails.application
+         .config
+         .filter_parameters
+         .select { |p| key.downcase.include?(p.to_s) }
+         .size
+         .positive?
+  end
+
+  def filtered_token(chars)
+    chars = chars.to_s
+    return '*' * chars.size if chars.size < 4
+
+    average = chars.size / 4
+    prefix = chars[0..average - 1]
+    hidden = '*' * (average * 2)
+    suffix = chars[(prefix.size + average * 2)..-1]
+    "#{prefix}#{hidden}#{suffix}"
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,6 +25,10 @@ module ApplicationHelper
     user_signed_in? || (Setting.guest_mode && !devise_page?)
   end
 
+  def demo_mode?
+    Setting.demo_mode
+  end
+
   def devise_page?
     contoller_name = params[:controller]
     contoller_name.start_with?('devise/') || contoller_name == 'users/registrations'

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -118,6 +118,8 @@ class Setting < RailsSettings::Base
           type: :boolean, display: true
     field :guest_mode, default: ActiveModel::Type::Boolean.new.cast(ENV['ZEALOT_GUEST_MODE'] || 'false'),
           type: :boolean, restart_required: true, display: true
+    field :keep_uploads, default: ActiveModel::Type::Boolean.new.cast(ENV['ZEALOT_KEEP_UPLOADS'] || 'true'),
+          type: :boolean, restart_required: true, display: true
     field :demo_mode, default: ActiveModel::Type::Boolean.new.cast(ENV['ZEALOT_DEMO_MODE'] || 'false'),
           type: :boolean, readonly: true, display: true
   end
@@ -179,13 +181,6 @@ class Setting < RailsSettings::Base
     keep_time: 604800,
     pg_schema: 'public',
   }
-
-  # 杂项
-  scope :misc do
-    # 上传文件保留策略
-    field :keep_uploads, default: ActiveModel::Type::Boolean.new.cast(ENV['ZEALOT_KEEP_UPLOADS'] || 'true'),
-          type: :boolean, restart_required: true, display: true
-  end
 
   # 版本信息（只读）
   scope :information do

--- a/app/views/admin/settings/index.html.slim
+++ b/app/views/admin/settings/index.html.slim
@@ -34,7 +34,7 @@ form.form-horizontal
 
                 display_value = case value
                                 when Hash
-                                  JSON.pretty_generate(value)
+                                  pretty_json(value)
                                 when Array
                                   value.join(', ')
                                 when TrueClass
@@ -47,7 +47,10 @@ form.form-horizontal
               dl.system-info
                 dt = t("admin.settings.#{key}")
                 dd
-                  - if params[:readonly]
+                  - if params[:readonly] || (value.is_a?(Hash) && secure_key?(value))
                     pre.disabled = display_value
                   - else
                     pre = link_to display_value, edit_admin_setting_path(key)
+
+                  - if key == 'demo_mode'
+                    small = t('admin.settings.demo_mode_tips')

--- a/app/views/admin/system_info/index.html.slim
+++ b/app/views/admin/system_info/index.html.slim
@@ -110,7 +110,7 @@
             dt = key
             dd
               pre
-                = value
+                = secure_value(key, value)
 
     .card.collapsed-card
       .card-header

--- a/config/locales/zealot/en.yml
+++ b/config/locales/zealot/en.yml
@@ -72,7 +72,8 @@ en:
       switch_mode: Switch mode
       registrations_mode: Registrations mode
       guest_mode: Guest mode
-      demo_mode: Demo mode (Reset data daily)
+      demo_mode: Demo mode
+      demo_mode_tips: 'Enable demo mode will: RESET data daily, CAN NOT destroy or edit default admin user profile, Filtered secure key and read only'
 
       third_party_auth: Third pary auth
       ldap: LDAP

--- a/config/locales/zealot/zh-CN.yml
+++ b/config/locales/zealot/zh-CN.yml
@@ -65,14 +65,15 @@ zh-CN:
       site_locale: 网站语言
       site_domain: 网站域名
 
-      presets: 默认值
+      presets: 预设值
       default_schemes: 应用类型模板
-      default_role: 初始化权限
+      default_role: 新用户权限
 
       switch_mode: 模式开关
       registrations_mode: 注册模式
-      guest_mode: 开启游客模式
-      demo_mode: 演示模式（定时恢复默认数据）
+      guest_mode: 游客模式
+      demo_mode: 演示模式
+      demo_mode_tips: 开启演示模式会触发：每天定时恢复默认数据；无法编辑或删除默认管理员；隐私数据会安全化显示且无法编辑
 
       third_party_auth: 第三方登录
       ldap: LDAP
@@ -80,8 +81,8 @@ zh-CN:
       gitlab: Gitlab
       google_oauth: Google OAuth
 
-      backup: 备份
-      misc: 杂项
+      # backup: 备份
+      # misc: 杂项
 
       stmp: 邮件配置
       mailer_default_from: 默认邮件发件地址


### PR DESCRIPTION
通过此次安全限制可以让线上体验的版本可以看到 90% 以上的功能的同时隐藏配置的私有密钥的同时并保证其安全性