### PR TITLE
渠道和版本详情采用更简练的 URI 规则

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -7,9 +7,12 @@ class Admin::SettingsController < ApplicationController
   def index
     @title = t('.title')
     @settings = Setting.site_configs
+    authorize @settings
   end
 
   def edit
+    authorize @setting
+
     @title = t('.title')
     @value = @setting.value || @setting.default_value
 
@@ -26,6 +29,8 @@ class Admin::SettingsController < ApplicationController
   end
 
   def update
+    authorize @setting
+
     @title = t('.title')
     new_value = setting_param[:value]
     new_value = JSON.parse(new_value) if setting_param[:type] == 'hash' || setting_param[:type] == 'array'
@@ -43,6 +48,8 @@ class Admin::SettingsController < ApplicationController
   end
 
   def destroy
+    authorize @setting
+
     key = @setting.var
     @setting.destroy
 
@@ -53,7 +60,6 @@ class Admin::SettingsController < ApplicationController
 
   def set_setting
     @setting = Setting.find_or_default(var: params[:id])
-    authorize @setting
   end
 
   def setting_param

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -25,10 +25,14 @@ class Admin::UsersController < ApplicationController
   end
 
   def edit
+    authorize @user
+
     @title = @user.email
   end
 
   def update
+    authorize @user
+
     if helpers.default_admin_in_demo_mode?(@user)
       return redirect_to admin_users_path, alert: t('errors.messages.invaild_in_demo_mode')
     end
@@ -46,6 +50,8 @@ class Admin::UsersController < ApplicationController
       return redirect_to admin_users_path, alert: t('errors.messages.invaild_in_demo_mode')
     end
 
+    authorize @user
+
     @user.destroy
     redirect_to admin_users_path, notice: t('activerecord.success.destroy', key: t('users.title'))
   end
@@ -54,7 +60,6 @@ class Admin::UsersController < ApplicationController
 
   def set_user
     @user = User.find(params[:id])
-    authorize @user
   end
 
   def user_params

--- a/app/controllers/admin/web_hooks_controller.rb
+++ b/app/controllers/admin/web_hooks_controller.rb
@@ -10,6 +10,7 @@ class Admin::WebHooksController < ApplicationController
   end
 
   def show
+    authorize @web_hook
     @title = t('admin.web_hooks.show')
   end
 
@@ -28,10 +29,12 @@ class Admin::WebHooksController < ApplicationController
   end
 
   def edit
+    authorize @web_hook
     @title = t('admin.web_hooks.edit')
   end
 
   def update
+    authorize @web_hook
     channel_ids = web_hook_params.delete(:channel_ids)
     return render :edit unless @web_hook.update(web_hook_params)
 
@@ -39,6 +42,7 @@ class Admin::WebHooksController < ApplicationController
   end
 
   def destroy
+    authorize @web_hook
     @web_hook.destroy
     redirect_to admin_web_hooks_url, notice: t('activerecord.success.destroy', key: t('web_hooks.title'))
   end
@@ -47,7 +51,6 @@ class Admin::WebHooksController < ApplicationController
 
   def set_web_hook
     @web_hook = WebHook.find(params[:id])
-    authorize @web_hook
   end
 
   def web_hook_params

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  include ExceptionHandler
   include Pundit
 
   # Prevent CSRF attacks by raising an exception.
@@ -12,14 +13,6 @@ class ApplicationController < ActionController::Base
   before_action :set_locale
   before_action :set_sentry_context
   before_action :record_page_view
-
-  rescue_from ActiveRecord::RecordNotFound, ActionController::RoutingError, with: :not_found
-  rescue_from ActionController::InvalidAuthenticityToken, with: :unprocessable_entity
-  rescue_from ActionController::UnknownFormat, AppInfo::Error, with: :not_acceptable
-  rescue_from ActionController::ParameterMissing, CarrierWave::InvalidParameter,
-              JSON::ParserError, AppInfo::UnkownFileTypeError, with: :bad_request
-  rescue_from HTTP::Error, OpenSSL::SSL::SSLError, with: :internal_server_error
-  rescue_from Pundit::NotAuthorizedError, with: :forbidden
 
   def raise_not_found
     raise ActionController::RoutingError, t('errors.messages.not_match_url', url: params[:unmatched_route])
@@ -45,58 +38,5 @@ class ApplicationController < ActionController::Base
 
   def record_page_view
     ActiveAnalytics.record_request(request)
-  end
-
-  def forbidden(e)
-    message = t('errors.messages.not_authorized_policy', query: e.query, model: e.record.class)
-    new_exception = StandardError.new(message)
-    new_exception.set_backtrace(e.backtrace)
-
-    respond_with_error(403, new_exception)
-  end
-
-  def not_found(e)
-    respond_with_error(404, e)
-  end
-
-  def gone(e)
-    respond_with_error(410, e)
-  end
-
-  def unprocessable_entity(e)
-    respond_with_error(422, e)
-  end
-
-  def not_acceptable(e)
-    respond_with_error(406, e)
-  end
-
-  def bad_request(e)
-    respond_with_error(400, e)
-  end
-
-  def internal_server_error(e)
-    respond_with_error(500, e)
-  end
-
-  def service_unavailable(e)
-    respond_with_error(503, e)
-  end
-
-  def respond_with_error(code, exception)
-    if code >= 500
-      logger.error exception.full_message
-      Sentry.capture_exception exception
-    end
-
-    respond_to do |format|
-      @code = code
-      @exception = exception
-      @title = t("errors.code.#{@code}.title")
-      @message = exception.message if code < 500
-
-      format.any  { render 'errors/index', status: code, formats: [:html] }
-      format.json { render json: { code: code, error: Rack::Utils::HTTP_STATUS_CODES[code] }, status: code }
-    end
   end
 end

--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -13,6 +13,7 @@ class AppsController < ApplicationController
   end
 
   def show
+    authorize @app
     @title = @app.name
   end
 
@@ -25,6 +26,8 @@ class AppsController < ApplicationController
   end
 
   def edit
+    authorize @app
+
     @title = t('.title')
   end
 
@@ -40,6 +43,8 @@ class AppsController < ApplicationController
   end
 
   def update
+    authorize @app
+
     if app_params.member?(:scheme_attributes) && app_params.member?(:channel_attributes)
       flash[:alert] = t('apps.messages.failture.missing_schemes_and_channels')
       return render :edit
@@ -50,6 +55,8 @@ class AppsController < ApplicationController
   end
 
   def destroy
+    authorize @app
+
     @app.destroy
     destory_app_data
 
@@ -78,7 +85,6 @@ class AppsController < ApplicationController
 
   def set_app
     @app = App.find(params[:id])
-    authorize @app
   end
 
   def set_selected_schemes_and_channels

--- a/app/controllers/channels/branches_controller.rb
+++ b/app/controllers/channels/branches_controller.rb
@@ -22,6 +22,7 @@ class Channels::BranchesController < ApplicationController
   end
 
   def set_channel
-    @channel = Channel.friendly.find params[:channel_id]
+    @channel = Channel.friendly.find(params[:channel_id] || params[:channel])
+    authorize @channel, :brances?
   end
 end

--- a/app/controllers/channels/release_types_controller.rb
+++ b/app/controllers/channels/release_types_controller.rb
@@ -23,6 +23,7 @@ class Channels::ReleaseTypesController < ApplicationController
   end
 
   def set_channel
-    @channel = Channel.friendly.find params[:channel_id]
+    @channel = Channel.friendly.find(params[:channel_id] || params[:channel])
+    authorize @channel, :release_types?
   end
 end

--- a/app/controllers/channels/versions_controller.rb
+++ b/app/controllers/channels/versions_controller.rb
@@ -2,6 +2,7 @@
 
 class Channels::VersionsController < ApplicationController
   before_action :set_channel
+  before_action :set_version
 
   def index
     @title = @channel.app_name
@@ -15,7 +16,6 @@ class Channels::VersionsController < ApplicationController
   end
 
   def show
-    @version = params[:id]
     @title = @channel.app_name
     @subtitle = t('.subtitle', version: @version)
     @back_url = URI(request.referer || '').path
@@ -29,6 +29,11 @@ class Channels::VersionsController < ApplicationController
   private
 
   def set_channel
-    @channel = Channel.friendly.find params[:channel_id]
+    @channel = Channel.friendly.find(params[:channel_id] || params[:channel])
+    authorize @channel, :versions?
+  end
+
+  def set_version
+    @version = params[:id] || params[:name]
   end
 end

--- a/app/controllers/channels_controller.rb
+++ b/app/controllers/channels_controller.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 class ChannelsController < ApplicationController
-  before_action :authenticate_user!, except: :show
+  before_action :authenticate_user! unless Setting.guest_mode
   before_action :set_channel, only: %i[show edit update destroy]
   before_action :set_scheme, except: %i[show]
 
   def show
+    authorize @channel
     @web_hook = @channel.web_hooks.new
     @releases = @channel.releases
                         .page(params.fetch(:page, 1))
@@ -31,12 +32,16 @@ class ChannelsController < ApplicationController
   end
 
   def edit
+    authorize @channel
+
     @title = t('channels.edit.title', name: @scheme.app_name)
   end
 
   def update
+    authorize @channel
+
     @channel.update(channel_params)
-    redirect_to channel_path(@channel)
+    redirect_to friendly_channel_path(@channel)
   end
 
   def destroy
@@ -52,9 +57,7 @@ class ChannelsController < ApplicationController
   end
 
   def set_channel
-    @channel = Channel.friendly.find params[:id]
-    authorize @channel
-
+    @channel = Channel.friendly.find(params[:id] || params[:channel])
     @app = @channel.scheme.app
     @title = @channel.app_name
     @subtitle = t('channels.subtitle', total_scheme: @app.schemes.count, total_channel: @channel.scheme.channels.count)

--- a/app/controllers/concerns/exception_handler.rb
+++ b/app/controllers/concerns/exception_handler.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module ExceptionHandler
+  extend ActiveSupport::Concern
+
+  included do
+    rescue_from ActiveRecord::RecordNotFound, ActionController::RoutingError, with: :not_found
+    rescue_from ActionController::InvalidAuthenticityToken, with: :unprocessable_entity
+    rescue_from ActionController::UnknownFormat, AppInfo::Error, with: :not_acceptable
+    rescue_from ActionController::ParameterMissing, CarrierWave::InvalidParameter,
+                JSON::ParserError, AppInfo::UnkownFileTypeError, with: :bad_request
+    rescue_from HTTP::Error, OpenSSL::SSL::SSLError, with: :internal_server_error
+    rescue_from Pundit::NotAuthorizedError, with: :forbidden
+  end
+
+  private
+
+  def forbidden(e)
+    message = t('errors.messages.not_authorized_policy', query: e.query, model: e.record.class)
+    new_exception = StandardError.new(message)
+    new_exception.set_backtrace(e.backtrace)
+
+    respond_with_error(403, new_exception)
+  end
+
+  def not_found(e)
+    respond_with_error(404, e)
+  end
+
+  def gone(e)
+    respond_with_error(410, e)
+  end
+
+  def unprocessable_entity(e)
+    respond_with_error(422, e)
+  end
+
+  def not_acceptable(e)
+    respond_with_error(406, e)
+  end
+
+  def bad_request(e)
+    respond_with_error(400, e)
+  end
+
+  def internal_server_error(e)
+    respond_with_error(500, e)
+  end
+
+  def service_unavailable(e)
+    respond_with_error(503, e)
+  end
+
+  def respond_with_error(code, exception)
+    if code >= 500
+      logger.error exception.full_message
+      Sentry.capture_exception exception
+    end
+
+    respond_to do |format|
+      @code = code
+      @exception = exception
+      @title = t("errors.code.#{@code}.title")
+      @message = exception.message if code < 500
+
+      format.any  { render 'errors/index', status: code, formats: [:html] }
+      format.json { render json: { code: code, error: Rack::Utils::HTTP_STATUS_CODES[code] }, status: code }
+    end
+  end
+end

--- a/app/controllers/debug_files_controller.rb
+++ b/app/controllers/debug_files_controller.rb
@@ -29,6 +29,7 @@ class DebugFilesController < ApplicationController
   end
 
   def destroy
+    authorize @debug_file
     @debug_file.destroy
     redirect_to debug_files_url, notice: t('activerecord.success.destroy', key: t('debug_files.title'))
   end
@@ -37,7 +38,6 @@ class DebugFilesController < ApplicationController
 
   def set_debug_file
     @debug_file = DebugFile.find(params[:id])
-    authorize @debug_file
   end
 
   # Only allow a trusted parameter "white list" through.

--- a/app/controllers/releases_controller.rb
+++ b/app/controllers/releases_controller.rb
@@ -8,15 +8,16 @@ class ReleasesController < ApplicationController
 
   def index
     if @channel.releases.empty?
-      return redirect_to channel_path(@channel),
+      return redirect_to friendly_channel_path(@channel),
         notice: t('releases.messages.errors.not_found_release_and_redirect_to_channel')
     end
 
-    redirect_to channel_release_path(@channel, @channel.releases.last),
+    redirect_to friendly_channel_release_path(@channel, @channel.releases.last),
       notice: t('releases.messages.errors.not_found_release_and_redirect_to_latest_release')
   end
 
   def show
+    authorize @release
     @title = @release.app_name
   end
 
@@ -42,6 +43,7 @@ class ReleasesController < ApplicationController
   end
 
   def destroy
+    authorize @release
     @release.destroy
     redirect_to channel_versions_url(@channel), notice: t('activerecord.success.destroy', key: "#{t('apps.title')}")
   end
@@ -49,7 +51,7 @@ class ReleasesController < ApplicationController
   def auth
     if @channel.password == params[:password]
       cookies["app_release_#{@release.id}_auth"] = @channel.encode_password
-      redirect_to channel_release_path(@channel, @release)
+      redirect_to friendly_channel_release_path(@channel, @release)
     else
       @error_message = t('releases.messages.errors.invalid_password')
       render :show
@@ -75,7 +77,7 @@ class ReleasesController < ApplicationController
   end
 
   def set_channel
-    @channel = Channel.friendly.find params[:channel_id]
+    @channel = Channel.friendly.find params[:channel_id] || params[:channel]
   end
 
   def release_params
@@ -97,7 +99,7 @@ class ReleasesController < ApplicationController
       when 'Release'
         @title = t('releases.messages.errors.not_found_release')
         @link_title = t('releases.messages.errors.reidrect_channel_detal')
-        @link_href = channel_path(@channel)
+        @link_href = friendly_channel_path(@channel)
       end
     end
 

--- a/app/controllers/schemes_controller.rb
+++ b/app/controllers/schemes_controller.rb
@@ -7,14 +7,6 @@ class SchemesController < ApplicationController
   before_action :set_channel, only: %i[show]
   before_action :set_app
 
-  def show
-    if @channel
-      redirect_to channel_path(@channel)
-    else
-      redirect_to new_app_scheme_channel_path(@scheme.app, @scheme), alert: t('schemes.show.empty_channel')
-    end
-  end
-
   def new
     @title = t('schemes.new.title', app: @app.name)
     @scheme = Scheme.new
@@ -34,15 +26,18 @@ class SchemesController < ApplicationController
   end
 
   def edit
+    authorize @scheme
     @title = t('schemes.edit.title', app: @app.name)
   end
 
   def update
+    authorize @scheme
     @scheme.update(scheme_params)
     redirect_to app_path(@app)
   end
 
   def destroy
+    authorize @scheme
     @scheme.destroy
 
     redirect_to app_path(@app)
@@ -64,7 +59,6 @@ class SchemesController < ApplicationController
 
   def set_scheme
     @scheme = Scheme.find(params[:id])
-    authorize @scheme
   end
 
   def scheme_params
@@ -72,27 +66,7 @@ class SchemesController < ApplicationController
                              .permit(:name, channel_attributes: { name: [] })
   end
 
-  def set_channel
-    from_channel, segment = from_channel?
-    unless from_channel
-      @channel = @scheme.latest_channel
-      return
-    end
-
-    previouse_channel = Channel.friendly.find(segment[:id])
-    @channel = @scheme.channels.find_by(device_type:  previouse_channel.device_type)
-  end
-
   def process_scheme_params
     @channels = scheme_params[:channel_attributes][:name].reject(&:empty?)
-  end
-
-  def from_channel?
-    return [false, nil] unless referer = request.referer
-    return [false, nil] unless segment = Rails.application.routes.recognize_path(referer)
-
-    from_channel = segment[:controller] == 'channels' && segment[:action] == 'show'
-
-    [from_channel, segment]
   end
 end

--- a/app/controllers/teardowns_controller.rb
+++ b/app/controllers/teardowns_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TeardownsController < ApplicationController
-  before_action :authenticate_user! unless Setting.guest_mode
+  before_action :authenticate_user!, except: %[show]
   before_action :set_metadata, only: %i[show destroy]
 
   def index
@@ -12,6 +12,7 @@ class TeardownsController < ApplicationController
   end
 
   def show
+    authorize @metadata
     @title = t('.title', name: @metadata.name,
                 release_version: @metadata.release_version,
                 build_version: @metadata.build_version)
@@ -20,9 +21,11 @@ class TeardownsController < ApplicationController
   def new
     @title = t('.title')
     @metadata = Metadatum.new
+    authorize @metadata
   end
 
   def create
+    authorize @metadata
     @title = t('.title')
     parse_app
   rescue AppInfo::NotFoundError, ActiveRecord::RecordNotFound => e
@@ -50,6 +53,7 @@ class TeardownsController < ApplicationController
   end
 
   def destroy
+    authorize @metadata
     @metadata.destroy
 
     redirect_to teardowns_path, notice: t('activerecord.success.destroy', key: "#{t('teardowns.title')}")
@@ -59,7 +63,6 @@ class TeardownsController < ApplicationController
 
   def set_metadata
     @metadata = Metadatum.find(params[:id])
-    authorize @metadata
   end
 
   def parse_app

--- a/app/controllers/web_hooks_controller.rb
+++ b/app/controllers/web_hooks_controller.rb
@@ -16,21 +16,25 @@ class WebHooksController < ApplicationController
   end
 
   def destroy
+    authorize @web_hook
     @web_hook.destroy
     redirect_to_channel_url notice: t('activerecord.success.destroy', key: t('web_hooks.title'))
   end
 
   def disable
+    authorize @web_hook
     @channel.web_hooks.delete @web_hook
     redirect_to_channel_url notice: t('admin.web_hooks.messages.success.disable')
   end
 
   def enable
+    authorize @web_hook
     @web_hook.channels << @channel
     redirect_to channel_url(@channel, anchor: 'enabled'), notice: t('admin.web_hooks.messages.success.enable')
   end
 
   def test
+    authorize @web_hook
     event = params[:event] || 'upload_events'
     AppWebHookJob.perform_later event, @web_hook, @channel
     redirect_to_channel_url notice: t('admin.web_hooks.messages.success.test')
@@ -44,7 +48,6 @@ class WebHooksController < ApplicationController
 
   def set_web_hook
     @web_hook = WebHook.find(params[:id])
-    authorize @web_hook
   end
 
   def web_hook_params
@@ -55,6 +58,6 @@ class WebHooksController < ApplicationController
   end
 
   def redirect_to_channel_url(**options)
-    redirect_to channel_path(@channel), **options
+    redirect_to friendly_channel_path(@channel), **options
   end
 end

--- a/app/helpers/apps_helper.rb
+++ b/app/helpers/apps_helper.rb
@@ -56,14 +56,22 @@ module AppsHelper
     return unless branch = release.branch
     return if branch.blank?
 
-    link_to(branch, channel_branches_path(release.channel, name: branch))
+    if params[:name] == branch
+      branch
+    else
+      link_to(branch, friendly_channel_branches_path(release.channel, name: branch))
+    end
   end
 
   def release_type_url(release)
     return unless release_type = release.release_type
     return if release_type.blank?
 
-    link_to(release_type, channel_release_types_path(release.channel, name: release_type))
+    if params[:name] == release_type
+      release_type
+    else
+      link_to(release_type, friendly_channel_release_types_path(release.channel, name: release_type))
+    end
   end
 
   def display_app_device(value)

--- a/app/helpers/channels_helper.rb
+++ b/app/helpers/channels_helper.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module ChannelsHelper
+  def using_friendly_channel_path(scheme, channel)
+    channel = scheme.channels.find_by(device_type:  channel.device_type)
+    friendly_channel_path(channel)
+  end
+end

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -141,7 +141,7 @@ class Release < ApplicationRecord
   end
 
   def download_url
-    download_release_url(id)
+    channel_release_download_path(channel, id)
   end
 
   def install_url
@@ -156,7 +156,7 @@ class Release < ApplicationRecord
   end
 
   def qrcode_url(size = :thumb)
-    channel_release_qrcode_url channel, self, size: size
+    channel_release_qrcode_url(channel, self, size: size)
   end
 
   def file_extname

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -13,7 +13,7 @@ class ApplicationPolicy
   end
 
   def show?
-    scope.where(id: record.id).exists? || Setting.guest_mode || user?
+    scope.where(id: record.id).exists? || guest_mode_or_signed_in?
   end
 
   def create?

--- a/app/policies/channel_policy.rb
+++ b/app/policies/channel_policy.rb
@@ -1,6 +1,19 @@
 # frozen_string_literal: true
 
 class ChannelPolicy < ApplicationPolicy
+
+  def versions?
+    guest_mode_or_signed_in?
+  end
+
+  def branches?
+    guest_mode_or_signed_in?
+  end
+
+  def release_types?
+    guest_mode_or_signed_in?
+  end
+
   class Scope < Scope
     def resolve
       scope.all

--- a/app/policies/metadatum_policy.rb
+++ b/app/policies/metadatum_policy.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 class MetadatumPolicy < ApplicationPolicy
+
+  def show?
+    guest_mode_or_signed_in?
+  end
+
   class Scope < Scope
     def resolve
       scope.all

--- a/app/policies/release_policy.rb
+++ b/app/policies/release_policy.rb
@@ -1,6 +1,15 @@
 # frozen_string_literal: true
 
 class ReleasePolicy < ApplicationPolicy
+
+  def show?
+    true
+  end
+
+  def auth?
+    true
+  end
+
   class Scope < Scope
     def resolve
       scope.all

--- a/app/views/apps/show.html.slim
+++ b/app/views/apps/show.html.slim
@@ -31,7 +31,7 @@
                   - scheme.channels.each do |channel|
                     tr
                       td
-                        = link_to channel.name, channel_path(channel)
+                        = link_to channel.name, friendly_channel_path(channel)
                       td style="width: 120px"
                         = button_link_to '', edit_app_scheme_channel_path(@app, scheme, channel), 'edit', class: 'btn-box-tool'
                         = button_link_to '', app_scheme_channel_path(@app, scheme, channel), 'trash-alt', class: 'btn-box-tool', data: { confirm: "#{t('apps.messages.confirm.delete_app_channel', name: channel.app_name)}", method: "delete" }

--- a/app/views/channels/_activity.html.slim
+++ b/app/views/channels/_activity.html.slim
@@ -16,7 +16,7 @@
               = app_icon(release, class: 'img-circle')
             .product-info
               a.product-title href="javascript:void(0)"
-                = link_to release.name || release.app_name, channel_release_path(release.channel, release)
+                = link_to release.name || release.app_name, friendly_channel_release_path(release.channel, release)
               small
                 span.badge.badge-light.float-right data-toggle="tooltip" title="#{release.created_at}"
                   = time_ago_in_words(release.created_at)

--- a/app/views/channels/_channels.html.slim
+++ b/app/views/channels/_channels.html.slim
@@ -5,4 +5,4 @@
     ul.nav.nav-pills.flex-column
       - @channel.scheme.channels.each do |channel|
         li.nav-item
-          = link_to display_app_device(channel), channel_path(channel), class: "nav-link #{params[:id] == channel.slug ? 'active' : ''}"
+          = link_to display_app_device(channel), friendly_channel_path(channel), class: "nav-link #{(params[:id] || params[:channel]) == channel.slug ? 'active' : ''}"

--- a/app/views/channels/_mobile_menu.html.slim
+++ b/app/views/channels/_mobile_menu.html.slim
@@ -16,4 +16,4 @@ nav.filter-nav.navbar.navbar-expand.navbar-white.d-block.d-sm-none
         - @channel.scheme.channels.each do |channel|
           - if channel != @channel
             li
-              = link_to display_app_device(channel), channel_path(channel), class: "dropdown-item"
+              = link_to display_app_device(channel), friendly_channel_path(channel), class: "dropdown-item"

--- a/app/views/channels/_schemes.html.slim
+++ b/app/views/channels/_schemes.html.slim
@@ -1,6 +1,3 @@
-ruby:
-  @schemes = @app.schemes
-
 .card.card-solid.d-none.d-sm-block
   .card-header
     h3.card-title = t('channels.show.scheme')
@@ -8,5 +5,5 @@ ruby:
     ul.nav.nav-pills.flex-column
       - @app.schemes.each do |scheme|
         li.nav-item
-          a.nav-link href="#{app_scheme_path(@app, scheme)}" class="#{@channel.scheme.name == scheme.name ? 'active' : ''}"
+          a.nav-link href="#{using_friendly_channel_path(scheme, @channel)}" class="#{@channel.scheme.name == scheme.name ? 'active' : ''}"
             = scheme.name

--- a/app/views/channels/_versions.html.slim
+++ b/app/views/channels/_versions.html.slim
@@ -12,12 +12,12 @@
         - @versions.each do |version|
           tr
             td
-              = link_to version, channel_version_path(@channel, version)
+              = link_to version, friendly_channel_version_path(@channel, version)
             td
               = @channel.release_version_count(version)
     - else
       .p-3 = t('channels.show.empty_version_shortly')
   - if @versions.count > 0
     .card-footbar
-      a.btn.btn-default.btn-block href="#{channel_versions_path(@channel)}"
+      a.btn.btn-default.btn-block href="#{friendly_channel_versions_path(@channel)}"
         = t('channels.show.more')

--- a/app/views/channels/filters/_list.slim
+++ b/app/views/channels/filters/_list.slim
@@ -14,9 +14,12 @@
       - @releases.each_with_index do |release, index|
         tr
           td
-            = link_to index + 1, channel_release_path(release.channel, release)
+            = link_to index + 1, friendly_channel_release_path(release.channel, release)
           td
-            = link_to release.release_version, channel_version_path(release.channel, release.release_version)
+            - if release.release_version == (params[:id] || params[:name])
+              = release.release_version
+            - else
+              = link_to release.release_version, friendly_channel_version_path(release.channel, release.release_version)
           td
             = release.build_version
           td

--- a/app/views/channels/filters/index.slim
+++ b/app/views/channels/filters/index.slim
@@ -10,7 +10,7 @@
       .card-header
         h3.card-title = @subtitle
         .card-tools
-          a href="#{channel_path(@channel)}"
+          a href="#{friendly_channel_path(@channel)}"
             i.icon.far.fa-list-alt
             = t('links.back_to_list')
       .table-responsive

--- a/app/views/dashboards/_recently_upload.html.slim
+++ b/app/views/dashboards/_recently_upload.html.slim
@@ -27,7 +27,7 @@ section
                       i.icon.fas.fa-clock
                       = time_ago_in_words(release.created_at)
                     h3.timeline-header
-                      = link_to(release.app_name, channel_release_path(release.channel, release), class: 'pr-1')
+                      = link_to(release.app_name, friendly_channel_release_path(release.channel, release), class: 'pr-1')
                       = t('dashboard.timeline.upload_release', release_version: release.release_version, build_version: release.build_version)
                     - if release.changelog.present?
                       .timeline-body.pb-1

--- a/app/views/releases/body/_activity.html.slim
+++ b/app/views/releases/body/_activity.html.slim
@@ -20,7 +20,7 @@ ruby:
                 i.icon.fas.fa-clock
                 = time_ago_in_words(release.created_at)
               h3.timeline-header
-                = link_to release.app_name, channel_release_path(@release.channel, release), class: 'pr-1'
+                = link_to release.app_name, friendly_channel_release_path(release.channel, release), class: 'pr-1'
                 = t('releases.show.upload_release', release_version: release.release_version, build_version: release.build_version)
               - if release.changelog.present?
                 .timeline-body.pb-0
@@ -45,4 +45,4 @@ ruby:
         div
           i.fas.fa-clock.bg-gray
     .card-footbar
-      a.btn.btn-default.btn-block href="#{channel_path(@release.channel)}" = t('releases.show.more')
+      a.btn.btn-default.btn-block href="#{friendly_channel_path(@release.channel)}" = t('releases.show.more')

--- a/app/views/releases/body/_metadata.html.slim
+++ b/app/views/releases/body/_metadata.html.slim
@@ -9,7 +9,7 @@
             release_version: latest_release.release_version, \
             build_version: latest_release.build_version, \
             time: time_ago_in_words(latest_release.created_at), \
-            link: link_to(t('releases.show.view_latest_version'), channel_release_path(latest_release.channel, latest_release)))
+            link: link_to(t('releases.show.view_latest_version'), friendly_channel_release_path(latest_release.channel, latest_release)))
 
 .app-detail.card
   .card-header
@@ -24,7 +24,7 @@
       - if @release.name.present?
         li title="#{t('releases.show.name')}"
           i.fas.fa-list-ul
-          = link_to @release.app_name, channel_path(@release.channel)
+          = link_to @release.app_name, friendly_channel_path(@release.channel)
       li title="#{t('releases.show.version')}"
         i.fab.fa-gg
         = @release.version

--- a/app/views/releases/new.html.slim
+++ b/app/views/releases/new.html.slim
@@ -11,7 +11,7 @@
         h3.card-title
           = @title
         .card-tools
-          a href="#{channel_path(@channel)}"
+          a href="#{friendly_channel_path(@channel)}"
             i.icon.far.fa-list-alt
             = t('links.back_to_list')
       .card-body

--- a/app/views/releases/show.html.slim
+++ b/app/views/releases/show.html.slim
@@ -15,7 +15,7 @@
         a.btn.btn-success.btn-block.mb-3 href="#{new_channel_release_path(@channel)}" = t('releases.new.title')
       == render 'releases/sidebar/qrcode'
       == render 'releases/sidebar/version'
-      a.btn.btn-default.btn-block href="#{channel_path(@channel)}" = t('releases.show.view_detail')
+      a.btn.btn-default.btn-block href="#{friendly_channel_path(@channel)}" = t('releases.show.view_detail')
   - else
     .col-md-12
       .card

--- a/app/views/releases/sidebar/_version.html.slim
+++ b/app/views/releases/sidebar/_version.html.slim
@@ -15,5 +15,5 @@ ruby:
         - channel.release_versions.each do |version|
           tr
             td
-              = link_to version, channel_version_path(channel.slug, version)
+              = link_to version, friendly_channel_version_path(channel.slug, version)
 

--- a/app/views/teardowns/show.html.slim
+++ b/app/views/teardowns/show.html.slim
@@ -8,6 +8,6 @@
         h5 = t('.related_app')
         p
           = t('.related_body')
-          = link_to @metadata.release.app_name, channel_release_path(@metadata.release.channel, @metadata.release)
+          = link_to @metadata.release.app_name, friendly_channel_release_path(@metadata.release.channel, @metadata.release)
 
   == render @metadata.platform.to_s.downcase

--- a/app/views/udid/show.html.slim
+++ b/app/views/udid/show.html.slim
@@ -71,7 +71,7 @@
                     i.icon.fas.fa-clock
                     = time_ago_in_words(release.created_at)
                   h3.timeline-header
-                    = link_to(release.app_name, channel_release_path(channel, release), class: 'pr-1')
+                    = link_to(release.app_name, friendly_channel_release_path(channel, release), class: 'pr-1')
                     = t('udid.show.upload_release', release_version: release.release_version, build_version: release.build_version)
                   - if release.changelog.present?
                     .timeline-body.pb-0

--- a/app/views/web_hooks/_item.html.slim
+++ b/app/views/web_hooks/_item.html.slim
@@ -18,7 +18,7 @@ tr
         - if shared_channel == current_channel
           = t('web_hooks.current_channel')
         - else
-          = link_to shared_channel.app_name, channel_path(shared_channel)
+          = link_to shared_channel.app_name, friendly_channel_path(shared_channel)
   td style="width: 70px"
     - if type == :enabled
       .btn-group-vertical

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
   # App
   #############################################
   resources :apps do
-    resources :schemes do
+    resources :schemes, except: %i[show] do
       resources :channels, except: %i[index show]
     end
   end
@@ -43,6 +43,7 @@ Rails.application.routes.draw do
       end
     end
 
+    # TODO: remove whole channels module
     scope module: :channels do
       resources :versions, only: %i[index show], id: /(.+)+/
       resources :branches, only: %i[index]
@@ -165,6 +166,19 @@ Rails.application.routes.draw do
   # API v2
   #############################################
   post '/graphql', to: 'graphql#execute'
+
+  #############################################
+  # URL Friendly
+  #############################################
+  scope path: ':channel', as: :friendly do
+    get '', to: 'channels#show', as: 'channel'
+    get 'versions', to: 'channels/versions#index', as: 'channel_versions'
+    get 'versions/:name', to: 'channels/versions#show', name: /(.+)+/, as: 'channel_version'
+    get 'release_types/:name', to: 'channels/release_types#index', name: /(.+)+/, as: 'channel_release_types'
+    get 'branches/:name', to: 'channels/branches#index', name: /(.+)+/, as: 'channel_branches'
+    get ':id', to: 'releases#show', as: 'channel_release'
+    # get ':id/download', to: 'download/releases#show', as: 'channel_release_download'
+  end
 
   #############################################
   # Development Only


### PR DESCRIPTION
之前的 URI 路由规则有些比较冗长，在先兼容现有规则的基础上新增一套更简练的路由方式

Before | After
---|---
/channels/:channel_id | :channel_id
/channels/:channel_id/releases/:id | /:channel_id/:id
/channels/:channel_id/versions | /:channel_id/versions
/channels/:channel_id/versions/:name |  /:channel_id/versions/:name
/channels/:channel_id/branches/:name |  /:channel_id/branches/:name
/channels/:channel_id/release_types/:name |  /:channel_id/release_types/:name
/apps/:app_id/schemes/:scheme_id | -

