### PR TITLE
修复上传应用没有传 channel_key 来自动创建应用及渠道

### DIFF
--- a/app/controllers/api/apps/upload_controller.rb
+++ b/app/controllers/api/apps/upload_controller.rb
@@ -87,7 +87,7 @@ class Api::Apps::UploadController < Api::BaseController
 
   def and_scheme(app)
     name = parse_scheme_name
-    app.schemes.find_or_create_by name: name
+    app.schemes.find_or_create_by(name: name)
   end
 
   def and_app
@@ -100,9 +100,10 @@ class Api::Apps::UploadController < Api::BaseController
   end
 
   def parse_scheme_name
-    return unless app_parser.os == AppInfo::Platform::IOS
+    default_name = t('api.apps.upload.create.adhoc')
+    return default_name unless app_parser.os == AppInfo::Platform::IOS
 
-    t("api.apps.upload.create.#{app_parser.release_type.downcase}", default: t('api.apps.upload.create.adhoc'))
+    t("api.apps.upload.create.#{app_parser.release_type.downcase}", default: default_name)
   end
 
   def release_params

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -9,8 +9,10 @@ class Api::BaseController < ActionController::API
   rescue_from TypeError, with: :render_unmatched_bundle_id_serror
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found_entity_response
   rescue_from ActiveRecord::RecordInvalid, with: :record_invalid
-  rescue_from ActionCable::Connection::Authorization::UnauthorizedError, with: :render_unauthorized_user_key
-  rescue_from ArgumentError, NoMethodError, PG::Error, with: :render_internal_server_error
+  rescue_from ActionCable::Connection::Authorization::UnauthorizedError,
+              with: :render_unauthorized_user_key
+  rescue_from ActiveRecord::RecordNotSaved, ArgumentError, NoMethodError,
+              PG::Error, with: :render_internal_server_error
   rescue_from ActionController::ParameterMissing, CarrierWave::InvalidParameter,
               AppInfo::UnkownFileTypeError, with: :render_missing_params_error
   rescue_from ActionController::UnknownFormat, with: :not_acceptable


### PR DESCRIPTION
修复 #779 

只会在上传 Android 应用时 100% 复现