### PR TITLE
兼容 Caddy 2.5.0 变更造成部分 url 跳 http

### DIFF
--- a/docker/rootfs/etc/Caddyfile
+++ b/docker/rootfs/etc/Caddyfile
@@ -22,6 +22,8 @@ log {
 reverse_proxy @zealot {
   to localhost:3000
 
+  header_up X-Forwarded-Proto https
+
   @accel header X-Accel-Redirect *
   handle_response @accel {
     root    * /app/public
@@ -35,8 +37,4 @@ reverse_proxy @zealot {
     rewrite * /500.html
     file_server
   }
-
-  # websockets
-  # header Connection *Upgrade*
-  # header Upgrade websocket
 }


### PR DESCRIPTION
解决 #788 #789 

Caddy 2.5.0 涉及的点如下：

- Reverse proxy: The X-Forwarded-Host header will now be automatically set, along with X-Forwarded-For and X-Forwarded-Proto.
- ⚠️ Reverse proxy: Incoming X-Forwarded-* headers will no longer be automatically trusted, to prevent spoofing. Now, trusted_proxies must be configured to specify a list of downstream proxies which are trusted to have sent good values. You only need to configure trusted proxies if Caddy is not the first server being connected to. For example, if you have Cloudflare in front of Caddy, then you should configure this with Cloudflare's [list of IP ranges](https://www.cloudflare.com/en-ca/ips/).