### PR TITLE
修复 iOS 图标无法获取

### DIFF
--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -96,7 +96,9 @@ class Release < ApplicationRecord
            when AppInfo::Platform::IOS
             return if parser.icons.blank?
 
-            biggest_icon(parser.icons, file_key: :uncrushed_file)
+            # NOTE: uncrushed_file may be return nil (#1196)
+            biggest_icon(parser.icons, file_key: :uncrushed_file) ||
+              biggest_icon(parser.icons, file_key: :file)
            when AppInfo::Platform::MACOS
              return if parser.icons.blank?
 


### PR DESCRIPTION
关联 #1196 解决采用了多备用图标特性无法获取图标的问题。

当前只是临时修复，核心问题是 iOS 之前图标都会 pngcrush 压缩成非标 PNG 文件，zealot 获取后需要解压缩，从这次反馈的问题找到测试包发现图标实际上是没有压缩，默认获取解压缩文件返回 `nil` 造成的