### PR TITLE
修复上传应用对应用类型的判断

### DIFF
--- a/app/models/concerns/release_parser.rb
+++ b/app/models/concerns/release_parser.rb
@@ -15,6 +15,10 @@ module ReleaseParser
     parser ||= AppInfo.parse(self.file.path)
     build_metadata(parser, default_source)
     relates_to_devices(parser)
+  rescue AppInfo::UnknownFormatError
+    # ignore
+  rescue => e
+    logger.error e.full_message
   ensure
     parser&.clear!
   end


### PR DESCRIPTION
之前因为重构上传应用部分代码删除了忽略应用类型判断，造成上传会强制解包应用 metadata 而无法上传的错误