### PR TITLE
开放 macOS 系统获取设备 UDID 功能

### DIFF
--- a/app/controllers/udid_controller.rb
+++ b/app/controllers/udid_controller.rb
@@ -49,10 +49,11 @@ class UdidController < ApplicationController
   def register
     apple_key = AppleKey.find(device_params[:apple_keys])
     name = device_params[:name]
-    name = [ 'Zealot', params[:product], SecureRandom.hex(4) ].compact.join('-') if name.blank? # Max 50 chars
-    udid = params[:udid]
+    udid = device_params[:udid]
+    platform = device_params[:platform].downcase.include?('iphone') ? 'IOS' : 'MAC_OS'
+    name = [ 'Zealot', platform, SecureRandom.hex(4) ].compact.join('-') if name.blank? # Max 50 chars
 
-    new_device = apple_key.register_device(udid, name)
+    new_device = apple_key.register_device(udid, name, platform)
     unless new_device.valid?
       logger.debug "Register failed with errors: #{new_device.errors}"
       error_message = new_device.errors.messages[:devices][0]
@@ -130,6 +131,6 @@ class UdidController < ApplicationController
   end
 
   def device_params
-    params.require(:device).permit(:name, :apple_keys, :sync_to_apple_key)
+    @device_params ||= params.require(:device).permit(:name, :udid, :platform, :apple_keys, :sync_to_apple_key)
   end
 end

--- a/app/javascript/controllers/udid_controller.js
+++ b/app/javascript/controllers/udid_controller.js
@@ -13,10 +13,10 @@ export default class extends Controller {
     if (isiOS()) {
       this.qrcodeTarget.classList.add("d-none")
     } else if (isMacOS()) {
-      this.tipTarget.innerHTML = this.macosTipValue
+      this.tipTarget.innerText = this.macosTipValue
     } else {
       this.installTarget.classList.add("d-none")
-      this.tipTarget.innerHTML = this.nonappleTipValue
+      this.tipTarget.innerText = this.nonappleTipValue
     }
 
     this.renderDebugZone

--- a/app/javascript/controllers/udid_controller.js
+++ b/app/javascript/controllers/udid_controller.js
@@ -1,21 +1,22 @@
 import { Controller } from "@hotwired/stimulus"
-import { uaParser, isiOS, isNonAppleOS } from "./utils"
+import { uaParser, isiOS, isMacOS } from "./utils"
 
 export default class extends Controller {
   static targets = ["qrcode", "install", "tip", "debug"]
   static values = {
     appleTip: String,
+    macosTip: String,
     nonappleTip: String
   }
 
   connect() {
-    if (isNonAppleOS()) {
-      this.installTarget.classList.add("d-none")
-      this.tipTarget.innerHTML = this.nonappleTipValue
-    } else if (isiOS()) {
+    if (isiOS()) {
       this.qrcodeTarget.classList.add("d-none")
+    } else if (isMacOS()) {
+      this.tipTarget.innerHTML = this.macosTipValue
     } else {
       this.installTarget.classList.add("d-none")
+      this.tipTarget.innerHTML = this.nonappleTipValue
     }
 
     this.renderDebugZone

--- a/app/models/apple_key.rb
+++ b/app/models/apple_key.rb
@@ -37,12 +37,12 @@ class AppleKey < ApplicationRecord
     false
   end
 
-  def register_device(udid, name = nil)
+  def register_device(udid, name = nil, platform = 'IOS')
     if (existed_device = Device.find_by(udid: udid))
       return existed_device
     end
 
-    response_device = client.create_device(udid, name).to_model
+    response_device = client.create_device(udid, name, platform: platform).to_model
     Device.create_from_api(response_device) do |device|
       devices << device
 

--- a/app/views/udid/_register_form.html.slim
+++ b/app/views/udid/_register_form.html.slim
@@ -1,6 +1,6 @@
 .col-md-12
   .card
-    = simple_form_for(Device.new, url: register_udid_path(udid: udid, product: product)) do |f|
+    = simple_form_for(Device.new, url: register_udid_path) do |f|
       .card-header
         h3.card-title
           = t("udid.show.register_device")
@@ -8,6 +8,8 @@
       .card-body
         = f.error_notification
         = f.input :name
+        = f.input :udid, as: :hidden, input_html: { value: udid }
+        = f.input :platform, as: :hidden, input_html: { value: product }
         = f.input :apple_keys, collection: AppleTeam.all_names, label_method: :first, value_method: :last, include_blank: false
 
       .card-footer

--- a/app/views/udid/index.html.slim
+++ b/app/views/udid/index.html.slim
@@ -8,6 +8,7 @@
   .col-md-12[
     data-controller="udid"
     data-udid-apple-tip-value="#{t('.apple_tip')}"
+    data-udid-macos-tip-value="#{t('.macos_tip')}"
     data-udid-nonapple-tip-value="#{t('.nonapple_tip')}"
   ]
     .card

--- a/config/locales/zealot/en.yml
+++ b/config/locales/zealot/en.yml
@@ -689,6 +689,7 @@ en:
     title: Fetch UDID
     index:
       apple_tip: Use iPhone or iPad to scan the QR Code to install
+      macos_tip: System limited to detect macOS's chip. choose to use the iPhone and iPad scan code or press button to get the device UDID please.
       nonapple_tip: :udid.index.apple_tip
       fetch_udid: Get your UDID now
       help:
@@ -696,17 +697,22 @@ en:
         body_html: |
           <p>
             UDID is an abbreviation for Unique Device Identifier (UDID). The UDID is a feature provided by Apple to identify iOS devices.
-            Apple uses the UDID to communicate between Apple servers and individual iOS devices. This allows Apple to associate the
+            Apple uses the UDID to communicate between Apple servers and individual iOS devices or macOS on arm chip. This allows Apple to associate the
             Apple ID and the Cloud ID with the corresponding iOS device. Each iOS device has an unique ID.
           </p>
           <p>
-            The UDID of your iOS devices is needed if you want to install alpha and beta iOS apps onto your device before they are released to the official apple store.
+            The UDID of your iOS devices or macOS on arm chip is needed if you want to install alpha and beta apps onto your device before they are released to the official apple store.
           </p>
           <strong>Following the steps:</strong>
           <ol>
-            <li>Click "Accept" to download profile</li>
-            <li>Open "Setting.app" -> "Downloaded profile" -> "Fetch device's UDID" -> Install</li>
-            <li>After install it will open Safari and redirect a result page then delete the profile automatically</li>
+            <li>Click "Accept" to fetching the profile file.</li>
+            <li>Open installed Profile.
+              <ol>
+                <li>iOS: Open "Setting.app" -> "Downloaded profile" -> "Fetch device's UDID" -> Install.</li>
+                <li>macOS: Open the profile named <code>install.mobileconfig</code> then open "System Settings" and click "Profile" in left sidebar menu.</li>
+              </ol>
+            </li>
+            <li>After install it will open Safari and redirect a result page then delete the profile automatically.</li>
           </ol>
     show:
       title: Device

--- a/config/locales/zealot/zh-CN.yml
+++ b/config/locales/zealot/zh-CN.yml
@@ -683,6 +683,7 @@ zh-CN:
     title: 设备 UDID
     index:
       apple_tip: 请使用 iPhone 或 iPad 扫描二维码获取
+      macos_tip: 系统限制无法检测 macOS 芯片类型，请自行选择使用 iPhone、iPad 扫码或点击下面按钮获取设备 UDID
       nonapple_tip: :'udid.index.apple_tip'
       fetch_udid: 获取设备 UDID
       help:
@@ -696,7 +697,12 @@ zh-CN:
           <strong>获取步骤</strong>
           <ol>
             <li>点击系统会弹窗的 “允许” 下载描述文件</li>
-            <li>打开手机 “设置” 找到顶部的 “已下载描述文件” 点击可以待安装的 “获取设备UDID” 的描述文件</li>
+            <li>打开描述文件
+              <ol>
+                <li>iOS: 打开手机 “设置” 找到顶部的 “已下载描述文件” 点击可以待安装的 “获取设备UDID” 的描述文件</li>
+                <li>macOS: 在下载路径双击打开 <code>install.mobileconfig</code>，打开系统设置点击左侧菜单的 "描述文件"</li>
+              </ol>
+            </li>
             <li>一路点击 “安装” 并输入锁屏密码允许安装描述文件</li>
             <li>安装之后描述文件会自动删除并跳转一个结果页面</li>
           </ol>


### PR DESCRIPTION
实现 #1384

- [x] macOS 获取设备 UDID（因系统限制同时展示二维码和获取按钮）
- [x] 注册 macOS 到苹果开发者

相关截图：

macOS 获取设备 UDID
<img width="1359" alt="iShot_2024-02-29_14 52 25" src="https://github.com/tryzealot/zealot/assets/17814/c2551a3f-a138-4763-8fc2-b84bd18f1da5">

注册 macOS 到苹果开发者
<img width="1055" alt="iShot_2024-02-29_14 51 26" src="https://github.com/tryzealot/zealot/assets/17814/36a2bd54-a908-4410-bff7-ed367310d3b2">

