### PR TITLE
修复无 bundle_id 获取最新版本逻辑错误

### DIFF
--- a/app/models/concerns/release_url.rb
+++ b/app/models/concerns/release_url.rb
@@ -12,9 +12,7 @@ module ReleaseUrl
   end
 
   def install_url
-    if platform.casecmp?('unknown') || platform.casecmp?('android') || platform.casecmp?('macos')
-      return download_url
-    end
+    return download_url unless platform == 'iOS'
 
     ios_url = channel_release_install_url(channel.slug, id)
     "itms-services://?action=download-manifest&url=#{ios_url}"

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -48,6 +48,25 @@ class Release < ApplicationRecord
     end
   end
 
+  def self.find_since_version(release_version, build_version)
+    current_release = select(:id).find_by(
+      release_version: release_version,
+      build_version: build_version
+    )
+
+    prepared_releases = if current_release
+      where('id > ?', current_release.id).order(id: :desc)
+    else
+      newer_versions = release_versions.select { |version| ge_version(version, release_version) }
+      where(elease_version: newer_versions,).order(id: :desc)
+    end
+
+    prepared_releases.select { |release|
+      ge_version(release.release_version, release_version) &&
+        gt_version(release.build_version, build_version)
+    }
+  end
+
   def app_name
     "#{app.name} #{scheme.name} #{channel.name}"
   end

--- a/app/serializers/api/latest_app_serializer.rb
+++ b/app/serializers/api/latest_app_serializer.rb
@@ -12,6 +12,15 @@ class Api::LatestAppSerializer < ApplicationSerializer
     bundle_id = instance_options[:bundle_id]
     release_version = instance_options[:release_version]
     build_version = instance_options[:build_version]
+
+    if bundle_id.blank?
+      if release_version.blank? && build_version.blank?
+        return object.releases.order(version: :desc)
+      else
+        return object.releases.find_since_version(release_version, build_version)
+      end
+    end
+
     if release_version.blank? && build_version.blank?
       object.releases.find_by(bundle_id: bundle_id)
     else


### PR DESCRIPTION
影响接口 `/api/apps/latest` 原先接口判断依赖 bundle_id 或 release_version+build_version，自支持 Windows 和 Linux 这类无法解析元数据的应用后这个逻辑忘记更新。

修复 https://github.com/tryzealot/zealot-docker/issues/15