### PR TITLE
Fix problem with encodings

### DIFF
--- a/app/controllers/admin/system_info_controller.rb
+++ b/app/controllers/admin/system_info_controller.rb
@@ -106,7 +106,7 @@ class Admin::SystemInfoController < ApplicationController
         obj.push(
           bytes_total: disk.bytes_total,
           bytes_used: disk.bytes_used,
-          mount_path: disk.path,
+          mount_path: disk.path&.force_encoding('UTF-8'),
           mount_options: mount.options,
           percent: percent,
           color: progress_color(percent)


### PR DESCRIPTION
If there are non-Unicode characters among the disk paths, we will receive an exception:
incompatible character encodings: ASCII-8BIT and UTF-8