### PR TITLE
Refactor: public for everyone in build release page by default

### DIFF
--- a/app/helpers/apps_helper.rb
+++ b/app/helpers/apps_helper.rb
@@ -71,10 +71,10 @@ module AppsHelper
     return if release_type.blank?
 
     title = release_type_name(release_type)
-    if params[:name] == release_type
-      title
-    else
+    if params[:name] != release_type && user_signed_in_or_guest_mode?
       link_to(title, friendly_channel_release_types_path(release.channel, name: release_type))
+    else
+      title
     end
   end
 

--- a/app/policies/release_policy.rb
+++ b/app/policies/release_policy.rb
@@ -3,9 +3,7 @@
 class ReleasePolicy < ApplicationPolicy
 
   def show?
-    return true if enabled_auth?
-
-    app_user?
+    true
   end
 
   def new?

--- a/app/views/releases/body/_metadata.html.slim
+++ b/app/views/releases/body/_metadata.html.slim
@@ -11,10 +11,7 @@
       - if @release.name.present?
         li title="#{t('releases.show.name')}" data-toggle="tooltip"
           i.fas.fa-list-ul
-          - if user_signed_in_or_guest_mode?
-            = link_to @release.app_name, friendly_channel_overview_path(@release.channel)
-          - else
-            = @release.app_name
+          = link_to_if user_signed_in_or_guest_mode?, @release.app_name, friendly_channel_overview_path(@release.channel)
       li title="#{t('releases.show.version')}" data-toggle="tooltip"
         i.fab.fa-gg
         = @release.version
@@ -56,7 +53,7 @@
         - if @release.ci_url.blank?
           = t("releases.sources.#{@release.source.downcase}", default: @release.source)
         - else
-          = link_to @release.source, @release.ci_url
+          = link_to_if user_signed_in_or_guest_mode?, @release.source, @release.ci_url
       - if @release.metadata.present? && user_signed_in_or_guest_mode?
         - if expired_date = @release.metadata.mobileprovision['expired_at']
           li title="#{t('releases.show.certificate_expired_date', date: expired_date)}" data-toggle="tooltip"
@@ -64,6 +61,6 @@
             = expired_date_tips(expired_date, colorful: false)
         li title="#{t('releases.show.metadata')}" data-toggle="tooltip"
           i.fas.fa-layer-group
-          = link_to t('releases.show.teardown_metadata'), teardown_path(@release.metadata)
+          = link_to_if user_signed_in_or_guest_mode?, t('releases.show.teardown_metadata'), teardown_path(@release.metadata)
 
     == render 'releases/body/install_app'

--- a/app/views/releases/show.html.slim
+++ b/app/views/releases/show.html.slim
@@ -13,8 +13,10 @@
     .col-md-4.col-lg-3
       - if current_user&.manage?
         = link_to t('releases.new.title'), new_channel_release_path(@channel), class: 'btn btn-success btn-block mb-3'
-      == render 'releases/sidebar/debug_file', debug_file: @release.debug_file
-      == render 'releases/sidebar/version', channel: @release.channel
+
+      - if user_signed_in_or_guest_mode?
+        == render 'releases/sidebar/debug_file', debug_file: @release.debug_file
+        == render 'releases/sidebar/version', channel: @release.channel
       == render 'releases/sidebar/qrcode'
       - if user_signed_in_or_guest_mode?
         = link_to t('.view_detail'), friendly_channel_overview_path(@channel), class: 'btn btn-default btn-block'


### PR DESCRIPTION
Relates to #1544 and discuss in telegram with user Ethan.

This needs change permission for anonymous user (a.k.a guest user) only.

Guest user Behavior | Before | After
---|---|---
View the build(release) of app | ✓ Guest mode enabled<br />✕ Guest mode disabled and Password Auth disbaled | ✓

Set password to internal visit to let it in private.