### PR TITLE
Rename permission user to member

### DIFF
--- a/app/helpers/collaborators_helper.rb
+++ b/app/helpers/collaborators_helper.rb
@@ -6,7 +6,6 @@ module CollaboratorsHelper
   end
 
   def edit_role_user?(collaborator)
-    target_role = collaborator.role
     return true if current_user.admin?
     return true if current_user.app_roles?(collaborator.app, :admin)
 

--- a/app/models/collaborator.rb
+++ b/app/models/collaborator.rb
@@ -7,7 +7,7 @@ class Collaborator < ApplicationRecord
   belongs_to :user
   belongs_to :app
 
-  enum role: %i[user developer admin]
+  enum role: %i[member developer admin]
 
   validates :owner, inclusion: [ true, false ]
   validates :role, presence: true, exclusion: { in: Collaborator.roles.values }

--- a/app/models/concerns/setting_helper.rb
+++ b/app/models/concerns/setting_helper.rb
@@ -16,7 +16,7 @@ module SettingHelper
 
     def builtin_roles
       {
-        user: I18n.t('settings.preset_role.user', default: 'User'),
+        member: I18n.t('settings.preset_role.member', default: 'Member'),
         developer: I18n.t('settings.preset_role.developer', default: 'Developer'),
         admin: I18n.t('settings.preset_role.admin', default: 'Admin')
       }

--- a/app/models/concerns/user_roles.rb
+++ b/app/models/concerns/user_roles.rb
@@ -6,7 +6,7 @@ module UserRoles
   included do
     scope :admins, -> { where(role: :admin) }
     scope :developers, -> { where(role: :developer) }
-    scope :users, -> { where(role: :user) }
+    scope :members, -> { where(role: :member) }
   end
 
   def manage?(app: nil)
@@ -18,7 +18,7 @@ module UserRoles
   end
 
   def revoke_admin!
-    update!(role: :user)
+    update!(role: :member)
   end
 
   def grant_developer!
@@ -26,7 +26,7 @@ module UserRoles
   end
 
   def revoke_developer!
-    update!(role: :user)
+    update!(role: :member)
   end
 
   def roles?(value)
@@ -44,7 +44,7 @@ module UserRoles
           elsif developer?
             :developer
           else
-            :user
+            :member
           end
 
     Setting.builtin_roles[key]

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -29,7 +29,7 @@ class Setting < RailsSettings::Base
   scope :presets do
     field :preset_schemes, default: builtin_schemes, type: :array, display: true,
           validates: { json: { format: :array } }
-    field :preset_role, default: 'user', type: :string, display: true,
+    field :preset_role, default: 'member', type: :string, display: true,
           validates: { presence: true, inclusion: { in: builtin_roles.keys.map(&:to_s) } }
     field :per_page, default: ENV.fetch('ZEALOT_PER_PAGE', '25').to_i, type: :integer, display: true,
           validates: { presence: true, numericality: { only_integer: true } }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ApplicationRecord
          :rememberable, :trackable, :validatable, :recoverable, :lockable,
          :omniauthable, omniauth_providers: %i[feishu gitlab google_oauth2 ldap openid_connect]
 
-  enum role: %i[user developer admin]
+  enum role: %i[member developer admin]
   enum locale: enum_roles
   enum appearance: enum_appearances
   enum timezone: enum_timezones
@@ -31,7 +31,7 @@ class User < ApplicationRecord
   private
 
   def set_default_role
-    self.role ||= Setting.preset_role || :user
+    self.role ||= Setting.preset_role || :member
   end
 
   def set_user_default_settings

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -40,7 +40,7 @@ class ApplicationPolicy
     Pundit.policy_scope!(user, record.class)
   end
 
-  delegate :admin?, :developer?, :manage?, :user?, to: :user, allow_nil: true
+  delegate :admin?, :developer?, :manage?, :member?, to: :user, allow_nil: true
 
   class Scope
     attr_reader :user, :scope

--- a/app/views/apps/_collaborators.html.slim
+++ b/app/views/apps/_collaborators.html.slim
@@ -20,7 +20,7 @@
               span.badge.badge-primary.ml-1 = t('apps.show.collaborator_owner')
             - if same_user?(collaborator)
               span.badge.badge-secondary.ml-1 = t('apps.show.it_is_you')
-          td = collaborator.role
+          td = t(collaborator.role, scope: 'settings.preset_role')
           td style="width: 120px"
             - if collaborator.owner?
               - if same_user?(collaborator) || current_user.admin?

--- a/config/locales/simple_form/simple_form.en.yml
+++ b/config/locales/simple_form/simple_form.en.yml
@@ -29,6 +29,7 @@ en:
         name: App name
       collaborator:
         user: User
+        role: Role
       scheme:
         name: Scheme name
         new_build_callout: New build callout

--- a/config/locales/simple_form/simple_form.zh-CN.yml
+++ b/config/locales/simple_form/simple_form.zh-CN.yml
@@ -29,6 +29,7 @@ zh-CN:
         name: 应用名称
       collaborator:
         user: 用户
+        role: 权限
       scheme:
         name: 类型名称
         new_build_callout: 新上传版本提示窗

--- a/config/locales/zealot/api.en.yml
+++ b/config/locales/zealot/api.en.yml
@@ -32,7 +32,7 @@ en:
 
         ### Personal access tokens
 
-        Personal access tokens (PATs) can be found in from the [user settings](/docs/user-guide/user_settings).
+        Personal access tokens (PATs) can be found in from the [user settings](https://zealot.ews.im/docs/user-guide/user_settings).
     servers:
       description: Demo server
     security:

--- a/config/locales/zealot/api.zh-CN.yml
+++ b/config/locales/zealot/api.zh-CN.yml
@@ -29,7 +29,7 @@ zh-CN:
 
         ### 用户密钥
 
-        用户密钥在[用户详情](/docs/user-guide/user_settings)最底部找到。
+        用户密钥在[用户详情](https://zealot.ews.im/zh-Hans/docs/user-guide/user_settings)最底部找到。
     servers:
       description: 演示服务器
     security:

--- a/config/locales/zealot/en.yml
+++ b/config/locales/zealot/en.yml
@@ -835,7 +835,7 @@ en:
       adhoc: Adhoc
       production: Production
     preset_role:
-      user: User
+      member: Member
       developer: Developer
       admin: Admin
     site_locale:

--- a/config/locales/zealot/zh-CN.yml
+++ b/config/locales/zealot/zh-CN.yml
@@ -829,7 +829,7 @@ zh-CN:
       adhoc: 内测版
       production: 产品版
     preset_role:
-      user: 用户
+      member: 用户
       developer: 开发者
       admin: 管理员
     site_locale:

--- a/spec/api/apps_spec.rb
+++ b/spec/api/apps_spec.rb
@@ -3,9 +3,6 @@
 require 'swagger_helper'
 
 RSpec.describe 'Apps API' do
-  let(:user) { create(:user) }
-  let(:app) { create(:app) }
-
   path '/apps' do
     get I18n.t('api.apps.index.title') do
       tags I18n.t('api.apps.default.tags')

--- a/swagger/v1/swagger_en.json
+++ b/swagger/v1/swagger_en.json
@@ -2578,11 +2578,11 @@
           "role": {
             "type": "string",
             "enum": [
-              "user",
+              "member",
               "developer",
               "admin"
             ],
-            "example": "user"
+            "example": "member"
           }
         }
       },
@@ -2797,7 +2797,7 @@
         "role": {
           "type": "string",
           "enum": [
-            "user",
+            "member",
             "developer",
             "admin"
           ],
@@ -2989,7 +2989,7 @@
           "type": "string",
           "default": "user",
           "enum": [
-            "user",
+            "member",
             "developer",
             "admin"
           ],

--- a/swagger/v1/swagger_zh-CN.json
+++ b/swagger/v1/swagger_zh-CN.json
@@ -2578,11 +2578,11 @@
           "role": {
             "type": "string",
             "enum": [
-              "user",
+              "member",
               "developer",
               "admin"
             ],
-            "example": "user"
+            "example": "member"
           }
         }
       },
@@ -2797,7 +2797,7 @@
         "role": {
           "type": "string",
           "enum": [
-            "user",
+            "member",
             "developer",
             "admin"
           ],
@@ -2989,7 +2989,7 @@
           "type": "string",
           "default": "user",
           "enum": [
-            "user",
+            "member",
             "developer",
             "admin"
           ],


### PR DESCRIPTION
Role `user` is a common term in Chinese, but it is not quite suitable in English and needs to be corrected promptly.

This is a tiny breaking changes for API, it need given new role `member` instead of `user` role to create/update app's collaborators.