### PR TITLE
Show prompt for restricted app when fetch UDID information

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,6 +6,9 @@ application.register("global", GlobalController)
 import ClipboardCenterController from "./clipboard_center_controller"
 application.register("clipboard-center", ClipboardCenterController)
 
+import installLimitedController from "./install_limited_controller"
+application.register("install-limited", installLimitedController)
+
 import ReleaseDownloadController from "./release_download_controller"
 application.register("release-download", ReleaseDownloadController)
 

--- a/app/javascript/controllers/install_limited_controller.js
+++ b/app/javascript/controllers/install_limited_controller.js
@@ -1,0 +1,34 @@
+import { Controller } from "@hotwired/stimulus"
+import { isiOS, isUserAgentLimited } from "./utils"
+
+export default class extends Controller {
+  static targets = [
+    "modal"
+  ]
+
+  static values = {
+    keywords: Array,
+    openSafari: String,
+    openBrower: String,
+  }
+
+  connect() {
+    if (isUserAgentLimited(this.keywordsValue)) {
+      return this.renderInstallLimited()
+    }
+  }
+
+  renderInstallLimited() {
+    console.log("sdfsfdsdffd")
+    let textNode = this.modalTarget.getElementsByClassName("text")[0]
+    let brNode = document.createElement("br")
+    textNode.appendChild(brNode)
+    if (isiOS()) {
+      textNode.appendChild(document.createTextNode(this.openSafariValue))
+    } else {
+      textNode.appendChild(document.createTextNode(this.openBrowerValue))
+    }
+
+    this.modalTarget.classList.remove("d-none")
+  }
+}

--- a/app/javascript/controllers/release_download_controller.js
+++ b/app/javascript/controllers/release_download_controller.js
@@ -6,7 +6,6 @@ const LOADING_TIMEOUT = 8000
 
 export default class extends Controller {
   static targets = [
-    "installLimited",
     "buttons",
 
     "installButton",
@@ -27,10 +26,6 @@ export default class extends Controller {
   }
 
   connect() {
-    if (this.isInstallLimited()) {
-      return this.renderInstallLimited()
-    }
-
     if (isiOS()) {
       this.showIntallButton()
       this.hideDownloadButton()
@@ -76,27 +71,6 @@ export default class extends Controller {
     if (this.hasDownloadButtonTarget) {
       this.downloadButtonTarget.classList.add("d-none")
     }
-  }
-
-  renderInstallLimited() {
-    let textNode = this.installLimitedTarget.getElementsByClassName("text")[0]
-    let brNode = document.createElement("br")
-    textNode.appendChild(brNode)
-    if (isiOS()) {
-      textNode.appendChild(document.createTextNode(this.openSafariValue))
-    } else {
-      textNode.appendChild(document.createTextNode(this.openBrowerValue))
-    }
-
-    this.installLimitedTarget.classList.remove("d-none")
-    this.buttonsTarget.classList.add("d-none")
-  }
-
-  isInstallLimited() {
-    let ua = navigator.userAgent
-    let matches = this.installLimitedValue.find(keyword => ua.includes(keyword))
-
-    return !!matches
   }
 
   sleep(ms) {

--- a/app/javascript/controllers/udid_controller.js
+++ b/app/javascript/controllers/udid_controller.js
@@ -2,7 +2,13 @@ import { Controller } from "@hotwired/stimulus"
 import { uaParser, isiOS, isMacOS } from "./utils"
 
 export default class extends Controller {
-  static targets = ["qrcode", "install", "tip", "debug"]
+  static targets = [
+    "qrcode",
+    "install",
+    "tip",
+    "debug"
+  ]
+
   static values = {
     appleTip: String,
     macosTip: String,

--- a/app/javascript/controllers/utils.js
+++ b/app/javascript/controllers/utils.js
@@ -51,4 +51,11 @@ const isNonAppleOS = () => {
   return !(os.name === "Mac OS" || os.name === "iOS")
 }
 
-export { poll, uaParser, isMacOS, isiOS, isNonAppleOS }
+const isUserAgentLimited = (keywords) => {
+  let ua = navigator.userAgent
+  let matches = keywords.find((keyword) => ua.includes(keyword))
+
+  return !!matches
+}
+
+export { poll, uaParser, isMacOS, isiOS, isNonAppleOS, isUserAgentLimited }

--- a/app/views/releases/body/_app_limited.html.slim
+++ b/app/views/releases/body/_app_limited.html.slim
@@ -1,9 +1,0 @@
-.install-limited.d-none data-release-download-target="installLimited"
-  .cover
-    .app-limited-tips
-      span.text.text-right
-        = t('releases.show.app_touch_menu')
-      = image_tag('icons/short-arrow.png')
-
-  .alert.alert-danger.alert-dismissible
-    h5 = t('releases.show.app_limited')

--- a/app/views/releases/body/_install_app.html.slim
+++ b/app/views/releases/body/_install_app.html.slim
@@ -1,13 +1,10 @@
 .app-actions[
   data-controller="release-download"
   data-release-download-install-url-value="#{@release.install_url}"
-  data-release-download-install-limited-value="#{Setting.preset_install_limited.to_json}"
   data-release-download-installing-value="<i class='fas fa-spin fa-sync'></i>#{t('releases.show.installing')}"
   data-release-download-installed-value="<i class='fas fa-download'></i>#{t('releases.show.installed')}"
-  data-release-download-open-safari-value="#{t('releases.show.app_open_in_safari')}"
-  data-release-download-open-brower-value="#{t('releases.show.app_open_in_webbrower')}"
 ]
-  == render 'releases/body/app_limited'
+  == render 'shared/install_limited', safari_text: t('releases.show.app_open_in_safari'), brower_text: t('releases.show.app_open_in_webbrower')
   == render 'releases/body/install_issues'
 
   .action-buttons data-release-download-target="buttons"

--- a/app/views/shared/_install_limited.html.slim
+++ b/app/views/shared/_install_limited.html.slim
@@ -1,0 +1,15 @@
+ruby:
+  attributes = {
+    "data-controller" => "install-limited",
+    "data-install-limited-keywords-value" => Setting.preset_install_limited.to_json,
+    "data-install-limited-target" => 'modal',
+    "data-install-limited-open-safari-value" => safari_text,
+    "data-install-limited-open-brower-value" => brower_text
+  }
+
+.install-limited.d-none *attributes
+  .cover
+    .app-limited-tips
+      span.text.text-right
+        = t('releases.show.app_touch_menu')
+      = image_tag('icons/short-arrow.png')

--- a/app/views/udid/index.html.slim
+++ b/app/views/udid/index.html.slim
@@ -11,6 +11,8 @@
     data-udid-macos-tip-value="#{t('.macos_tip')}"
     data-udid-nonapple-tip-value="#{t('.nonapple_tip')}"
   ]
+    == render 'shared/install_limited', safari_text: t('.app_open_in_safari'), brower_text: t('.app_open_in_webbrower')
+
     .card.mb-3
       .card-body.text-center data-udid-target="qrcode"
         = install_qrcode_image_tag

--- a/config/locales/zealot/en.yml
+++ b/config/locales/zealot/en.yml
@@ -438,7 +438,6 @@ en:
       api: API
     show:
       enter_password: Enter password
-      app_limited: Install limited in current app
       app_touch_menu: Click menu right-top corner
       app_open_in_safari: Choose "Open in Safari" and install
       app_open_in_webbrower: Open with any browser and install
@@ -785,7 +784,9 @@ en:
       apple_tip: Use iPhone or iPad to scan the QR Code to install
       macos_tip: System limited to detect macOS's chip. choose to use the iPhone and iPad scan code or press button to get the device UDID please.
       nonapple_tip: :udid.index.apple_tip
-      fetch_udid: Get your UDID now
+      fetch_udid: Fetch your UDID now
+      app_open_in_safari: Choose "Open in Safari" and fetch
+      app_open_in_webbrower: Open with any browser and fetch
       help:
         title: Why need to install profile to fetch your UDID?
         body_html: |

--- a/config/locales/zealot/zh-CN.yml
+++ b/config/locales/zealot/zh-CN.yml
@@ -434,7 +434,6 @@ zh-CN:
       api: 接口上传
     show:
       enter_password: 访问密码
-      app_limited: 无法在当前应用安装
       app_touch_menu: 点击右上角菜单
       app_open_in_safari: 在 Safari 中打开并安装
       app_open_in_webbrower: 在任意浏览器中打开并安装
@@ -766,6 +765,8 @@ zh-CN:
       macos_tip: 系统限制无法检测 macOS 芯片类型，请自行选择使用 iPhone、iPad 扫码或点击下面按钮获取设备 UDID
       nonapple_tip: :'udid.index.apple_tip'
       fetch_udid: 获取设备 UDID
+      app_open_in_safari: 在 Safari 中打开并获取
+      app_open_in_webbrower: 在任意浏览器中打开并获取
       help:
         title: 为什么要下载安装描述文件获取设备 UDID?
         body_html: |


### PR DESCRIPTION
When trying to fetch the UDID of a restricted app, show a prompt to the user explaining why the UDID cannot be obtained.

Relates to #1667 