### PR TITLE
Add native codes for Android

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ gem 'webp-ffi', '~> 0.4.0'
 # Helper
 gem 'rake', '~> 13.0.4'
 gem 'rails-settings-cached', '~> 2.9.5'
-gem 'app-info', '~> 3.2.0'
+gem 'app-info', '~> 3.3.0'
 gem 'faraday', '~> 2.12.1'
 gem 'rqrcode'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,11 +90,11 @@ GEM
     android_parser (2.7.0)
       rexml (> 3.0)
       rubyzip (>= 1.0, < 3.0)
-    app-info (3.2.0)
+    app-info (3.3.0)
       CFPropertyList (>= 2.3.4, < 3.1.0)
       android_parser (>= 2.7, < 3.0)
       base64 (~> 0.2.0)
-      google-protobuf (>= 4.27.1, < 5.0.0)
+      google-protobuf (>= 4.27.5, < 5.0.0)
       icns (~> 0.2.0)
       image_size (>= 1.5, < 3.5)
       nkf (~> 0.2.0)
@@ -205,19 +205,19 @@ GEM
       fugit (>= 1.11.0)
       railties (>= 6.1.0)
       thor (>= 1.0.0)
-    google-protobuf (4.28.2)
+    google-protobuf (4.28.3)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.28.2-aarch64-linux)
+    google-protobuf (4.28.3-aarch64-linux)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.28.2-arm64-darwin)
+    google-protobuf (4.28.3-arm64-darwin)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.28.2-x86_64-darwin)
+    google-protobuf (4.28.3-x86_64-darwin)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.28.2-x86_64-linux)
+    google-protobuf (4.28.3-x86_64-linux)
       bigdecimal
       rake (>= 13)
     graphiql-rails (1.10.1)
@@ -237,7 +237,7 @@ GEM
     image_size (3.4.0)
     interception (0.5)
     io-console (0.7.2)
-    iostruct (0.1.3)
+    iostruct (0.2.0)
     irb (1.14.1)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
@@ -639,7 +639,7 @@ PLATFORMS
 DEPENDENCIES
   active_model_serializers (~> 0.10.14)
   activejob-status (~> 1.0.2)
-  app-info (~> 3.2.0)
+  app-info (~> 3.3.0)
   awesome_print
   better_errors
   binding_of_caller

--- a/app/helpers/apps_helper.rb
+++ b/app/helpers/apps_helper.rb
@@ -28,8 +28,14 @@ module AppsHelper
     image_tag(release.icon_url, **options)
   end
 
-  def app_device(device)
+  def native_codes(release)
+    native_codes = release.native_codes
+    return if native_codes.blank?
 
+    count = native_codes.size
+    return t('releases.show.multi_native_codes') if count > 0
+    
+    native_codes[0]
   end
 
   def logged_in_or_without_auth?(release)

--- a/app/services/teardown_service.rb
+++ b/app/services/teardown_service.rb
@@ -72,12 +72,13 @@ class TeardownService
 
     metadata.bundle_id = parser.package_name
     metadata.target_sdk_version = parser.target_sdk_version
-    metadata.activities = parser&.activities&.select(&:present?).map(&:name)
-    metadata.permissions = parser&.use_permissions&.select(&:present?) || []
-    metadata.features = parser&.use_features&.select(&:present?) || []
-    metadata.services = parser&.services&.sort_by(&:name)&.select(&:present?)&.map(&:name) || []
-    metadata.url_schemes = parser&.schemes&.sort
-    metadata.deep_links = parser&.deep_links&.sort
+    metadata.activities = parser.activities&.select(&:present?).map(&:name)
+    metadata.permissions = parser.use_permissions&.select(&:present?) || []
+    metadata.features = parser.use_features&.select(&:present?) || []
+    metadata.services = parser.services&.sort_by(&:name)&.select(&:present?)&.map(&:name) || []
+    metadata.url_schemes = parser.schemes&.sort
+    metadata.deep_links = parser.deep_links&.sort
+    metadata.native_codes = parser.native_codes
 
     process_signature_certs(parser, metadata)
   end

--- a/app/views/releases/body/_metadata.html.slim
+++ b/app/views/releases/body/_metadata.html.slim
@@ -28,6 +28,10 @@
         li title="#{t('releases.show.release_type')}" data-bs-toggle="tooltip" data-bs-custom-class="default-tooltip"
           i.fas.fa-cubes
           = release_type_url_builder(release)
+      - if release.native_codes.present?
+        li title="#{t('releases.show.native_codes')} #{release.native_codes.join(', ')}" data-bs-toggle="tooltip" data-bs-custom-class="default-tooltip"
+          i.fas.fa-microchip
+          = native_codes(release)
       - if release.file.present?
         li title="#{t('releases.show.filesize')}" data-bs-toggle="tooltip" data-bs-custom-class="default-tooltip"
           i.fas.fa-weight

--- a/app/views/teardowns/_android.html.slim
+++ b/app/views/teardowns/_android.html.slim
@@ -2,7 +2,7 @@ ruby:
   begin
     app_name = @metadata.name
   rescue Android::NotFoundError
-    app_name = t('teardowns.show.unknow_app_name')
+    app_name = t('teardowns.show.unkonwn')
   end
 
 .col-md-6
@@ -26,6 +26,11 @@ ruby:
         dt = t('teardowns.show.package_name')
         dd
           pre = @metadata.packet_name
+        dt
+          = t('teardowns.show.native_codes')
+        dd
+          pre
+            = @metadata.native_codes.join(', ')
         dt
           = t('teardowns.show.supported_device')
         dd

--- a/app/views/teardowns/_harmonyos.html.slim
+++ b/app/views/teardowns/_harmonyos.html.slim
@@ -2,7 +2,7 @@ ruby:
   begin
     app_name = @metadata.name
   rescue Android::NotFoundError
-    app_name = t('teardowns.show.unknow_app_name')
+    app_name = t('teardowns.show.unkonwn')
   end
 
 .col-md-6

--- a/config/locales/zealot/en.yml
+++ b/config/locales/zealot/en.yml
@@ -449,6 +449,8 @@ en:
       device_type: Device
       release_version: Release version (build version)
       release_type: Release type
+      native_codes: Native codes
+      multi_native_codes: Universal
       filesize: File size
       uploaded_at: Uploaded time %{date}
       git_branch: Git branch
@@ -639,11 +641,12 @@ en:
       expired: Expired now!
       related_app: Release related
       related_body: This teardown was relates with %{link}
-      unknow_app_name: Unknown
+      unkonwn: Unknown
       metadata: Metadata
       app_name: App name
       version: Version
       package_name: Bundle id (package name)
+      native_codes: Native codes
       supported_device: Supported device
       android_min_sdk: Minimum SDK
       android_target_sdk: Target SDK

--- a/config/locales/zealot/zh-CN.yml
+++ b/config/locales/zealot/zh-CN.yml
@@ -445,6 +445,8 @@ zh-CN:
       device_type: 平台
       release_version: 构建版本
       release_type: 打包类型
+      native_codes: 原生架构
+      multi_native_codes: 多架构
       filesize: 文件体积
       uploaded_at: 上传时间 %{date}
       git_branch: Git 分支
@@ -629,11 +631,12 @@ zh-CN:
       expired: 刚好过期
       related_app: 关联提醒
       related_body: 当前解包关联的应用是%{link}
-      unknow_app_name: 未知
+      unkonwn: 未知
       metadata: 应用信息
       app_name: 名称
       version: 版本
       package_name: 包名
+      native_codes: 原生架构
       supported_device: 支持设备
       android_min_sdk: 最低支持版本
       android_target_sdk: 编译构建版本

--- a/db/migrate/20241127060125_add_native_codes_to_metadata.rb
+++ b/db/migrate/20241127060125_add_native_codes_to_metadata.rb
@@ -1,0 +1,5 @@
+class AddNativeCodesToMetadata < ActiveRecord::Migration[7.2]
+  def change
+    add_column :metadata, :native_codes, :jsonb, default: [], null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_07_07_040749) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_27_060125) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -258,6 +258,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_07_07_040749) do
     t.datetime "updated_at", null: false
     t.string "platform"
     t.jsonb "deep_links", default: [], null: false
+    t.jsonb "native_codes", default: [], null: false
     t.index ["checksum"], name: "index_metadata_on_checksum"
     t.index ["release_id"], name: "index_metadata_on_release_id"
     t.index ["user_id"], name: "index_metadata_on_user_id"
@@ -356,7 +357,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_07_07_040749) do
     t.datetime "locked_at", precision: nil
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "locale", default: "zh-CN", null: false
+    t.string "locale", default: "en", null: false
     t.string "appearance", default: "light", null: false
     t.string "timezone", default: "Asia/Shanghai", null: false
   end


### PR DESCRIPTION
This PR add native code shows both in teardown result page and app build detail page. it detect any native code is will render to the page, or leave it empty.

## Screenshots

### teardown result page

<img width="829" alt="Teardown result page" src="https://github.com/user-attachments/assets/2e0848d9-8ac8-459b-8db0-c0f9294f91d5">

### app build detail page

It shows `Universal` if native codes include multi-arch.

<img width="1233" alt="App build detail page" src="https://github.com/user-attachments/assets/35cccbf3-c19d-4fdc-beef-35ae6b6037ae">


Relates to #1735