### PR TITLE
New setting to configure footbar

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -211,7 +211,7 @@ module ApplicationHelper
   end
 
   def show_api
-    return unless openapi_ui_enabled?
+    return unless openapi_endpoints_enabled?
 
     locale = current_user&.locale || I18n.default_locale
     I18n.with_locale(locale) do
@@ -223,7 +223,7 @@ module ApplicationHelper
     end
   end
 
-  def openapi_ui_enabled?
-    Rails.application.routes.named_routes.key?(:api_openapi_ui) && Setting.openapi_ui
+  def openapi_endpoints_enabled?
+    Rails.application.routes.named_routes.key?(:api_openapi_ui) && Setting.show_footer_openapi_endpoints
   end
 end

--- a/app/models/concerns/setting_helper.rb
+++ b/app/models/concerns/setting_helper.rb
@@ -41,11 +41,14 @@ module SettingHelper
     def site_configs
       group_configs.each_with_object({}) do |(scope, items), obj|
         obj[scope] = items.each_with_object({}) do |item, inner|
+          puts item
           key = item[:key]
           value = send(key.to_sym)
+          restart_required = item[:options][:restart_required] || false
           inner[key] = {
             value: value,
-            readonly: item[:readonly]
+            readonly: item[:readonly],
+            restart_required: restart_required
           }
         end
       end

--- a/app/models/concerns/setting_suger.rb
+++ b/app/models/concerns/setting_suger.rb
@@ -15,6 +15,10 @@ module SettingSuger
     value == default_value
   end
 
+  def restart_required?
+    present[:restart_required]
+  end
+
   def default_value
     present[:default]
   end
@@ -46,7 +50,7 @@ module SettingSuger
     self.class.restart_required!
   end
 
-  def need_restart?
+  def restart_required?
     value_of(var, source: :restart_required) == true
   end
 

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -46,8 +46,6 @@ class Setting < RailsSettings::Base
           type: :boolean, restart_required: true, display: true
     field :keep_uploads, default: ActiveModel::Type::Boolean.new.cast(ENV['ZEALOT_KEEP_UPLOADS'] || 'true'),
           type: :boolean, restart_required: true, display: true
-    field :openapi_ui, default: ActiveModel::Type::Boolean.new.cast(ENV['ZEALOT_OPENAPI_UI_ENABLED'] || 'false'),
-          type: :boolean, restart_required: true, display: true
     field :demo_mode, default: ActiveModel::Type::Boolean.new.cast(ENV['ZEALOT_DEMO_MODE'] || 'false'),
           type: :boolean, readonly: true, display: true
   end
@@ -139,7 +137,15 @@ class Setting < RailsSettings::Base
       display: (value = ENV['GOOGLE_ANALYTICS_ID']) && value.present?
   end
 
-  # Backup settings
+  # misc settings
+  scope :misc do
+    field :show_footer_version, type: :boolean, display: true,
+      default: ActiveModel::Type::Boolean.new.cast(ENV['ZEALOT_SHOW_FOOTER_VERSION'] || 'true')
+    field :show_footer_openapi_endpoints, type: :boolean, restart_required: true, display: true,
+      default: ActiveModel::Type::Boolean.new.cast(ENV['ZEALOT_SHOW_FOOTER_OPENAPI_ENDPOINTS'] || 'false')
+  end
+
+  # Backup settings1
   field :backup, type: :hash, readonly: true, default: {
     path: 'public/backup',
     pg_schema: 'public',

--- a/app/views/admin/settings/_setting.html.slim
+++ b/app/views/admin/settings/_setting.html.slim
@@ -4,7 +4,13 @@ ruby:
 
 = turbo_frame_tag "setting_#{key}" do
   dl.system-info
-    dt = t("admin.settings.#{key}")
+    dt 
+      = t("admin.settings.#{key}")
+      - if params[:restart_required]
+        small.ps-2
+          | (
+          = t('admin.settings.index.restart_required')
+          | )
     dd
       - if params[:readonly] || (value.is_a?(Hash) && secure_key?(value))
         pre.disabled.mb-2

--- a/app/views/layouts/_footer.html.slim
+++ b/app/views/layouts/_footer.html.slim
@@ -4,4 +4,5 @@ footer.app-footer
 
   div
     span = powered_by
-    span.px-1 = zealot_version
+    - if Setting.show_footer_version
+      span.px-1 = zealot_version

--- a/config/locales/zealot/en.yml
+++ b/config/locales/zealot/en.yml
@@ -120,6 +120,7 @@ en:
         apply_for_restart: Apply for restart
         service_restarting: Service restarting ...
         service_restarted: Refresh page ...
+        restart_required: Restart required
       update:
         title: Edit setting
       edit:
@@ -145,15 +146,12 @@ en:
       guest_mode: Guest mode
       demo_mode: Demo mode
       demo_mode_hint: Enable demo mode will RESET data daily, CAN NOT destroy or edit default admin user profile, Filtered secure key and read only
-      openapi_ui: OpenAPI UI
-      openapi_ui_hint: Display the API link in footer section if enabled
       third_party_auth: Third-party Auth
       ldap: LDAP
       oidc: OpenID Connect
       feishu: Feihsu
       gitlab: Gitlab
       google_oauth: Google OAuth
-      #misc: 杂项
       smtp: Email SMTP
       mailer_default_from: Default email send from
       mailer_default_reply_to: Default email reply to
@@ -164,6 +162,9 @@ en:
       umami_website_id: Umami Website ID
       archives: Archive uploaded binaries
       keep_uploads: Keep all builds
+      misc: Misc
+      show_footer_version: Show Zealot version information in the footer.
+      show_footer_openapi_endpoints: Show OpenAPI documentation endpoints in the footer.
       empty_value: Empty
       no_editable_key: Read only
       reset: Reset to default value

--- a/config/locales/zealot/zh-CN.yml
+++ b/config/locales/zealot/zh-CN.yml
@@ -120,6 +120,7 @@ zh-CN:
         apply_for_restart: 需重启服务生效
         service_restarting: 服务重启中 ...
         service_restarted: 刷新页面 ...
+        restart_required: 重启后生效
       update:
         title: 编辑设置
       edit:
@@ -145,15 +146,12 @@ zh-CN:
       guest_mode: 游客模式
       demo_mode: 演示模式
       demo_mode_hint: 开启演示模式会触发：每天定时恢复默认数据；无法编辑或删除默认管理员；隐私数据会安全化显示且无法编辑
-      openapi_ui: OpenAPI UI
-      openapi_ui_hint: 开启后可在各页面底部找到 API 链接
       third_party_auth: 第三方登录
       ldap: LDAP
       oidc: OpenID Connect
       feishu: 飞书
       gitlab: Gitlab
       google_oauth: Google OAuth
-      # misc: 杂项
       smtp: 邮件配置
       mailer_default_from: 默认邮件发件地址
       mailer_default_reply_to: 默认邮件回复地址
@@ -164,6 +162,9 @@ zh-CN:
       umami_website_id: Umami 统计
       archives: 上传文件
       keep_uploads: 永久保存上传应用版本
+      misc: 杂项
+      show_footer_version: 显示底部版本号
+      show_footer_openapi_endpoints: 显示底部 OpenAPI 链接
       empty_value: 空值
       no_editable_key: 当前设置为可读，无法修改
       reset: 恢复默认值

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -233,7 +233,7 @@ Rails.application.routes.draw do
     resources :devices, only: %i[update]
     resources :version, only: :index
 
-    if Setting.openapi_ui
+    if Setting.show_footer_openapi_endpoints
       mount Rswag::Api::Engine => '/swagger', as: :openapi
       mount Rswag::Ui::Engine => '/swagger', as: :openapi_ui
     end


### PR DESCRIPTION
- Add new setting `show_footer_version` to show Zealot version information in the footer.
- (**breaking changes**) Rename `openapi_ui` to `show_footer_openapi_endpoints` to show OpenAPI documentation endpoints in the footer. previouse storaged setting will be invalid, needs to re-configure.