### PR TITLE
Throw required agreement missing or expired error

### DIFF
--- a/config/locales/zealot/en.yml
+++ b/config/locales/zealot/en.yml
@@ -117,9 +117,9 @@ en:
         smtp_verify_inprocess: Verification Inprocessing
         smtp_verify_success: Verification successful
         smtp_verify_failed: Verification failed
-        apply_for_restart: Apply for restart
-        service_restarting: Service restarting ...
-        service_restarted: Refresh page ...
+        apply_for_restart: Apply and Restart
+        service_restarting: Restarting
+        service_restarted: Refresh
         restart_required: Restart required
       update:
         title: Edit setting
@@ -1045,6 +1045,7 @@ en:
             key_id:
               unauthorized: Without authority, please check issuer id and private key.
               forbidden: Without permission, Apple key needs developer or high permissions.
+              required_agreement_missing_or_expired: Apple key needs agreement, please login to Apple Developer and accept the agreement.
               unknown: 'Unknown error: %{message}'
             devices:
               invalid_value: Register device %{value} was invalid.

--- a/config/locales/zealot/zh-CN.yml
+++ b/config/locales/zealot/zh-CN.yml
@@ -118,8 +118,8 @@ zh-CN:
         smtp_verify_success: 验证成功
         smtp_verify_failed: 验证失败
         apply_for_restart: 需重启服务生效
-        service_restarting: 服务重启中 ...
-        service_restarted: 刷新页面 ...
+        service_restarting: 服务重启中
+        service_restarted: 刷新页面
         restart_required: 重启后生效
       update:
         title: 编辑设置
@@ -1045,6 +1045,7 @@ zh-CN:
             key_id:
               unauthorized: 用户身份认证失败，请重新检查各项参数是否正确
               forbidden: 密钥权限太低，重新生成一个最低限度为【开发者】权限的密钥
+              required_agreement_missing_or_expired: 苹果开发者协议未同意或已过期，请重新登录苹果开发者网站同意协议后再重新执行当前操作
               unknown: '未知错误: %{message}'
             devices:
               invalid_value: 注册设备 %{value} 是无效的请检测后重新尝试


### PR DESCRIPTION
There are many possible errors with the Apple Connect API. One uncaught error is "A required agreement is missing or has expired". When adding an Apple Developer Key in the current system, this error does not trigger an explicit exception—instead, it only shows a message indicating that the private key's checksum can't be blank. This PR aims to address that specific issue.