### PR TITLE
Hide file checksum filed

### DIFF
--- a/app/models/apple_key.rb
+++ b/app/models/apple_key.rb
@@ -5,12 +5,12 @@ class AppleKey < ApplicationRecord
   has_many :apple_keys_devices, class_name: 'AppleKeyDevice'
   has_many :devices, through: :apple_keys_devices
 
-  validates :issuer_id, :key_id, :private_key, :filename, :checksum, presence: true
+  validates :issuer_id, :key_id, :private_key, :filename, presence: true
   validates :checksum, uniqueness: true, on: :create, if: :requires_fields?
   validate :private_key_format, on: :create, if: :requires_fields?
   validate :appstoreconnect_api_role_permissions, on: :create, if: :requires_fields?
 
-  before_create :generate_checksum
+  before_validation :generate_checksum
 
   def private_key_filename
     @private_key_filename ||= "#{key_id}.key"

--- a/app/views/admin/apple_keys/_form.html.slim
+++ b/app/views/admin/apple_keys/_form.html.slim
@@ -6,7 +6,7 @@
     = f.input :key_id, required: true
     - if @apple_key.new_record?
       = f.input :private_key, as: :file
-      - if @apple_key.errors.size > 0
+      - if @apple_key.errors[:checksum].present?
         = f.input :checksum, disabled: true
     - else
       = f.input :filename, disabled: true

--- a/app/views/debug_files/_form.html.slim
+++ b/app/views/debug_files/_form.html.slim
@@ -9,5 +9,6 @@
   = f.input :release_version
   = f.input :build_version
   = f.input :file, required: true
-  = f.input :checksum, disabled: true
+  - if @debug_file.errors[:checksum].present?
+    = f.input :checksum, disabled: true
   = f.button :submit

--- a/config/locales/simple_form/simple_form.en.yml
+++ b/config/locales/simple_form/simple_form.en.yml
@@ -64,7 +64,7 @@ en:
         release_version: Release version
         build_version: Build version
         file: File
-        checksum: File checksum
+        checksum: File Hash Verification
       setting:
         value: Value
       apple_key:
@@ -72,6 +72,7 @@ en:
         key_id: Key ID
         private_key: Private key
         devices: Devices
+        checksum: Private key Hash Verification
       apple_team:
         display_name: Display name
         name: Team name
@@ -87,52 +88,60 @@ en:
         max_keeps: Max keeps
         enabled: Enabled
         schedule_settings: Schedule settings
-        parsing: Parsing ...
+        parsing: Parsing
       device:
         name: Device name
         apple_keys: Apple Keys
         sync_to_apple_key: Synchronize to Apple developer
+
     hints:
       defaults:
-        channel: For example, the platform of app.
+        channel: For example, the platform of app
       app:
         schemes:
           name: :simple_form.hints.scheme.name
       scheme:
         name: Apply the type of feature to target audience
-        new_build_callout: Display a new callout at the top of the page when visiting a previous build of app.
-        retained_builds: Set the maximum retained versions, the earlier versions will be deleted automatically if exceeded, the default is 0 which means to retain all versions.
+        new_build_callout: Display a new callout at the top of the page when visiting a previous build of app
+        retained_builds: Set the maximum retained versions, the earlier versions will be deleted automatically if exceeded, the default is 0 which means to retain all versions
       channel:
-        name: Recommended distinguishing different channels according to the application platform, single platform applications can also be the name of the distribution market.
-        device_type: Which device type of app. for example, iOS, Android, macOS etc.
-        bundle_id: Validate the bundle id (package name) of app, leave empty or fill * to skip validate.
-        git_url: Git URL, for example, the repo URL of Github, Gitlab or self-host.
-        slug: A slug is the part of a URL that identifies a particular page on a website in an easy-to-read form.
-        password: Need password by fill it when user is not log in.
-        download_filename_type: Download file name generation rules.
+        name: Recommended distinguishing different channels according to the application platform, single platform applications can also be the name of the distribution market
+        device_type: Which device type of app. for example, iOS, Android, macOS etc
+        bundle_id: Validate the bundle id (package name) of app, leave empty or fill * to skip validate
+        git_url: Git URL, for example, the repo URL of Github, Gitlab or self-host
+        slug: A slug is the part of a URL that identifies a particular page on a website in an easy-to-read form
+        password: Need password by fill it when user is not log in
+        download_filename_type: Download file name generation rules
       release:
-        file: Support iOS, Android, HarmonyOS, macOS, Windows and Linux binary file.
+        file: Support iOS, Android, HarmonyOS, macOS, Windows and Linux binary file
         release_version: It is recommended to name the main version <a href="https://semver.org/lang/zh-CN/">X.Y.Z semantic version</a>
         build_version: Internal version number
-        changelog: What new features this app contains, fix what issues, and so on.
-        release_type: 'iOS: debug、adhoc, release; Android: debug, release.'
-        branch: Git branch. In general either main or develop.
+        changelog: What new features this app contains, fix what issues, and so on
+        release_type: 'iOS: debug、adhoc, release; Android: debug, release'
+        branch: Git branch. In general either main or develop
         git_commit: 40 bit length SHA value of git commit
         ci_url: The CI URL specific like Jenkins, Gitlab CI etc
       web_hook:
-        body: Custom JSON struct body to apply the third party notification services. Use <a href="https://zealot.ews.im/docs/user-guide/webhooks">default structure</a> by leave it empty.
+        body: Custom JSON struct body to apply the third party notification services. Use <a href="https://zealot.ews.im/docs/user-guide/webhooks">default structure</a> by leave it empty
       debug_file:
-        device_type: Which device type of app. for example, iOS, Android, macOS etc.
+        device_type: Which device type of app. for example, iOS, Android, macOS etc
         file: Zip compressed file required
+        checksum: Uniqueness verification of the debug file only
       backup:
         key: Unique backup key
         schedule: |
           Expression support<a href="https://github.com/floraison/fugit/blob/master/spec/nat_spec.rb">English Natural Language</a> or
-          <a href="https://crontab.guru/">Cron</a>.
-        max_keeps: Remove old backups if reach max keeps number, -1 means no limited, 0 never backup.
+          <a href="https://crontab.guru/">Cron</a>
+        max_keeps: Remove old backups if reach max keeps number, -1 means no limited, 0 never backup
+      apple_key:
+        issuer_id: UUID format, for example, 12345678-1234-1234-1234-123456789012
+        key_id: Make sure it mateches the downloaded private key file, for example, ABCDEFGH12
+        private_key: Accept private key files with any file extension. You can download it from Apple Developer account
+        checksum: Uniqueness verification of the private key file only
+
     placeholders:
       release:
-        changelog: The developer is lazy without leaving anything.
+        changelog: The developer is lazy without leaving anything
       web_hook:
         url: 'http://example.com/web-hooks'
         body: |
@@ -157,7 +166,6 @@ en:
       debug_file:
         release_version: '1.0.0'
         build_version: '1.0'
-        checksum: 'Ignore me, pure validate the file use'
       backup:
         schedule: every day at noon / 12 0 * * *
       device:

--- a/config/locales/simple_form/simple_form.zh-CN.yml
+++ b/config/locales/simple_form/simple_form.zh-CN.yml
@@ -64,7 +64,7 @@ zh-CN:
         release_version: 发布版本
         build_version: 构建版本
         file: 调试文件
-        checksum: 唯一校验码
+        checksum: 文件校验码
       setting:
         value: 值
       apple_key:
@@ -72,6 +72,7 @@ zh-CN:
         key_id: 密钥 ID
         private_key: 密钥文件
         devices: 测试设备
+        checksum: 密钥文件校验码
       apple_team:
         display_name: 显示名称
         name: 注册主体
@@ -125,12 +126,18 @@ zh-CN:
       debug_file:
         device_type: 应用设备类型
         file: 必须使用 zip 文件压缩后的调试文件
+        checksum: 仅用于做调试文件唯一性校验使用
       backup:
         key: 名称必须是唯一，不可和其他备份重复
         schedule: |
           表达式支持<a href="https://github.com/floraison/fugit/blob/master/spec/nat_spec.rb">英语语义</a>或
           <a href="https://crontab.guru/">Cron</a>，暂不支持单次执行
         max_keeps: 备份达到设置上限会删除最早的文件，-1 不限制设置; 0 不可备份
+      apple_key:
+        issuer_id: UUID 格式，例如 12345678-1234-1234-1234-123456789012
+        key_id: 确保和下载的密钥文件匹配，例如 ABCDEFGH12
+        private_key: 接受任意文件后缀格式的密钥文件，你可以从苹果开发者账户下载
+        checksum: 仅用于做密钥文件唯一性校验使用
 
     placeholders:
       release:
@@ -159,7 +166,6 @@ zh-CN:
       debug_file:
         release_version: '1.0.0'
         build_version: '1.0'
-        checksum: '纯校验使用，随文件生成无需填写'
       backup:
         schedule: every day at noon / 12 0 * * *
       device:

--- a/config/locales/zealot/en.yml
+++ b/config/locales/zealot/en.yml
@@ -1041,20 +1041,22 @@ en:
         apple_key:
           attributes:
             issuer_id:
-              missing_distribution_certificate: Create distribution certificate then try again.
+              missing_distribution_certificate: Create distribution certificate then try again
             key_id:
-              unauthorized: Without authority, please check issuer id and private key.
-              forbidden: Without permission, Apple key needs developer or high permissions.
-              required_agreement_missing_or_expired: Apple key needs agreement, please login to Apple Developer and accept the agreement.
+              unauthorized: Without authority, please check issuer id and private key
+              forbidden: Without permission, Apple key needs developer or high permissions
+              required_agreement_missing_or_expired: Apple key needs agreement, please login to Apple Developer and accept the agreement
               unknown: 'Unknown error: %{message}'
             devices:
-              invalid_value: Register device %{value} was invalid.
+              invalid_value: Register device %{value} was invalid
               api: 'Apple return error: %{message}'
               unknown: 'Unknown error: %{message}'
+            checksum:
+              taken: matched, the private key was existed
         udid:
           attributes:
             name:
-              invalid_value: Register device %{value} was invalid.
+              invalid_value: Register device %{value} was invalid
               api: 'Apple return error: %{message}'
               unknown: 'Unknown error: %{message}'
         debug_file:
@@ -1064,7 +1066,7 @@ en:
             file:
               blank: Choose a zip file with supported type
             checksum:
-              taken: File exists, cannot be uploaded
+              taken: matched, the debug file was existed
         backup:
           attributes:
             schedule:

--- a/config/locales/zealot/zh-CN.yml
+++ b/config/locales/zealot/zh-CN.yml
@@ -1051,6 +1051,8 @@ zh-CN:
               invalid_value: 注册设备 %{value} 是无效的请检测后重新尝试
               api: '苹果返回错误：%{message}'
               unknown: '未知错误: %{message}'
+            checksum:
+              taken: 匹配，密钥文件已存在
         udid:
           attributes:
             name:


### PR DESCRIPTION
For certain features, file creation requires the associated files to be unique. However, under specific error conditions, the checksum field may produce misleading messages that confuse users. Pre-generating the checksum helps prevent such cases and improves the overall user experience.