### PR TITLE
Improve webhook delivery reliability with retry and failure notification

### DIFF
--- a/config/locales/zealot/en.yml
+++ b/config/locales/zealot/en.yml
@@ -1024,6 +1024,7 @@ en:
       failures:
         empty_release: Not found any release to send test webhook.
         empty_url: Webhook URL is empty.
+        send_failed: "Failed to send webhook to %{url}: %{error}"
     debug_file:
       success: Debug file (%{id}) pare done, Refresh the web page after 3 seconds.
       failures:

--- a/config/locales/zealot/zh-CN.yml
+++ b/config/locales/zealot/zh-CN.yml
@@ -1019,6 +1019,7 @@ zh-CN:
       failures:
         empty_release: 没有找到上传应用版本去发送测试网络钩子
         empty_url: 网络钩子 URL 不能为空
+        send_failed: "发送网络钩子失败 %{url}: %{error}"
     debug_file:
       success: 调试文件 %{id} 解析完成，3 秒后自动刷新本页面
       failures:


### PR DESCRIPTION
## Summary

- ✅ Add automatic retry (3 attempts with exponential backoff)
- ✅ Treat non-2xx HTTP responses as errors
- ✅ Notify user only after all retries are exhausted
- ✅ Add bilingual error messages (EN/ZH-CN)

Fixes #2163

## Changes

### `app/jobs/app_web_hook_job.rb`

- Add `retry_on Faraday::Error` with `wait: :exponentially_longer, attempts: 3`
- Add `handle_webhook_failure` callback for post-retry notification
- Improve `send_request` to check `response.success?` and raise on non-2xx

### `config/locales/zealot/en.yml` & `zh-CN.yml`

- Add `active_job.webhook.failures.send_failed` translation key

## Before

- Network errors → logged only, silent failure
- HTTP 4xx/5xx → treated as success
- No user notification on failure

## After

- Network errors → retry 3 times with exponential backoff
- HTTP 4xx/5xx → trigger retry mechanism
- User notified after all retries exhausted