### PR TITLE
Fix GraphQL Security & Pundit Authorization

### DIFF
--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -1,17 +1,14 @@
 # frozen_string_literal: true
 
 class GraphqlController < ApplicationController
-  # If accessing from outside this domain, nullify the session
-  # This allows for outside API access while preventing CSRF attacks,
-  # but you'll have to authenticate your user separately
-  # protect_from_forgery with: :null_session
+  before_action :validate_bearer_token!
 
   def execute
     variables = prepare_variables(params[:variables])
     query = params[:query]
     operation_name = params[:operationName]
     context = {
-      current_user: validated_user,
+      current_user: current_user,
     }
     result = ZealotSchema.execute(query, variables: variables, context: context, operation_name: operation_name)
     render json: result
@@ -21,6 +18,13 @@ class GraphqlController < ApplicationController
   end
 
   private
+
+  # Validate Bearer token is present and valid
+  def validate_bearer_token!
+    return if validated_token.present?
+
+    render json: { errors: [{ message: 'Unauthorized' }] }, status: :unauthorized
+  end
 
   # Handle variables in form data, JSON body, or a blank value
   def prepare_variables(variables_param)
@@ -49,7 +53,11 @@ class GraphqlController < ApplicationController
     render json: { errors: [{ message: e.message, backtrace: e.backtrace }], data: {} }, status: 500
   end
 
-  def validated_user
+  def current_user
+    @current_user ||= validated_token
+  end
+
+  def validated_token
     auth_value = request.authorization
     return unless auth_value&.downcase&.start_with?('bearer')
 

--- a/app/graphql/concerns/graphql_authorization.rb
+++ b/app/graphql/concerns/graphql_authorization.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module GraphqlAuthorization
+  extend ActiveSupport::Concern
+
+  included do
+    include Pundit::Authorization
+  end
+
+  def authorize!(action, record)
+    policy = Pundit.policy!(current_user, record)
+
+    unless policy.public_send(:"#{action}?")
+      raise GraphQL::ExecutionError, "Not authorized to #{action} this resource"
+    end
+  end
+
+  def current_user
+    context[:current_user]
+  end
+end

--- a/app/graphql/types/base_object.rb
+++ b/app/graphql/types/base_object.rb
@@ -2,6 +2,8 @@
 
 module Types
   class BaseObject < GraphQL::Schema::Object
+    include GraphqlAuthorization
+
     # edge_type_class Types::BaseEdge
     # connection_type_class Types::BaseConnection
     field_class Types::BaseField

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -28,11 +28,15 @@ module Types
 
     # Then provide an implementation:
     def user(id:)
-      User.find(id)
+      user = User.find(id)
+      authorize!(:show, user)
+      user
     end
 
     def app(id:)
-      App.find(id)
+      app = App.find(id)
+      authorize!(:show, app)
+      app
     end
 
     def echo(message: nil)

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -4,8 +4,20 @@ module Types
   class UserType < Types::BaseObject
     field :id, ID, null: false
     field :username, String, null: true
-    field :email, String, null: false
-    field :token, String, null: false
+    field :email, String, null: false do
+      def authorize?(obj, args, context)
+        current_user = context[:current_user]
+        # User can see their own email, admins can see anyone's
+        current_user&.admin? || current_user&.id == obj.id
+      end
+    end
+    field :token, String, null: false do
+      def authorize?(obj, args, context)
+        current_user = context[:current_user]
+        # User can see their own token, admins can see anyone's
+        current_user&.admin? || current_user&.id == obj.id
+      end
+    end
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
   end
 end

--- a/app/graphql/validators/authenticated_validator.rb
+++ b/app/graphql/validators/authenticated_validator.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module GraphQL
+  module Validators
+    # Validates that a field requires an authenticated user
+    # Usage: field :some_field, String, null: false, validates: AuthenticatedValidator
+    class AuthenticatedValidator
+      def call(field_def, object, arguments, context)
+        current_user = context[:current_user]
+        return if current_user.present?
+
+        raise GraphQL::ExecutionError, 'Authentication required for this field'
+      end
+    end
+
+    # Validates that a user has admin role
+    class AdminOnlyValidator
+      def call(field_def, object, arguments, context)
+        current_user = context[:current_user]
+        return if current_user&.admin?
+
+        raise GraphQL::ExecutionError, 'Admin access required for this field'
+      end
+    end
+  end
+end


### PR DESCRIPTION
# GraphQL Security & Pundit Authorization

## Background

A high-severity vulnerability was reported in the GraphQL endpoint where:

1. **No authentication enforcement** — queries executed without any Bearer token
2. **Sensitive data exposure** — `email` and `token` field on `UserType` was returned by current user or who has admin role.
3. **No authorization checks** — any authenticated user could query any resource

## Security Fix

### Architecture

```
Request → Authentication → Query Authorization → Field Authorization → Response
           ↓                 ↓                     ↓
       Bearer token      Pundit policy          Field-level
       (Controller)      (Resolver)             (Type definition)
```

## Big Thanks

Thanks Sam Holmes sent my the full CVE details.