### PR TITLE
feat: add guest role for new user registrations 

### DIFF
--- a/app/controllers/download/releases_controller.rb
+++ b/app/controllers/download/releases_controller.rb
@@ -4,12 +4,10 @@ class Download::ReleasesController < ApplicationController
   before_action :set_release
 
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found_entity_response
+  rescue_from Pundit::NotAuthorizedError, with: :render_guest_not_authorized_response
 
   def show
-    if current_user&.guest?
-      return redirect_to channel_release_path(@release.channel, @release),
-        alert: I18n.t('releases.messages.errors.no_permission_to_download')
-    end
+    authorize @release, :download?
 
     # password protected check
     unless helpers.logged_in_or_without_auth?(@release)
@@ -22,10 +20,7 @@ class Download::ReleasesController < ApplicationController
   end
 
   def download
-    if current_user&.guest?
-      return redirect_to channel_release_path(@release.channel, @release),
-        alert: I18n.t('releases.messages.errors.no_permission_to_download')
-    end
+    authorize @release, :download?
 
     # 触发 web_hook
     @release.channel.perform_web_hook('download_events', current_user&.id)
@@ -42,6 +37,11 @@ class Download::ReleasesController < ApplicationController
     render json: {
       error: t('.not_found')
     }, status: :not_found
+  end
+
+  def render_guest_not_authorized_response
+    redirect_to channel_release_path(@release.channel, @release),
+      alert: I18n.t('releases.messages.errors.no_permission_to_download')
   end
 
   def set_release

--- a/app/controllers/download/releases_controller.rb
+++ b/app/controllers/download/releases_controller.rb
@@ -6,8 +6,13 @@ class Download::ReleasesController < ApplicationController
   rescue_from ActiveRecord::RecordNotFound, with: :render_not_found_entity_response
 
   def show
+    if current_user&.guest?
+      return redirect_to channel_release_path(@release.channel, @release),
+        alert: I18n.t('releases.messages.errors.no_permission_to_download')
+    end
+
     # password protected check
-    unless helpers.logged_in_or_without_auth?(@release) 
+    unless helpers.logged_in_or_without_auth?(@release)
       return redirect_to channel_release_path(@release.channel, @release, back_url: @release.download_url)
     end
 
@@ -17,6 +22,11 @@ class Download::ReleasesController < ApplicationController
   end
 
   def download
+    if current_user&.guest?
+      return redirect_to channel_release_path(@release.channel, @release),
+        alert: I18n.t('releases.messages.errors.no_permission_to_download')
+    end
+
     # 触发 web_hook
     @release.channel.perform_web_hook('download_events', current_user&.id)
 
@@ -34,10 +44,8 @@ class Download::ReleasesController < ApplicationController
     }, status: :not_found
   end
 
-
   def set_release
     @release = Release.find(params[:id])
   end
 end
-
 

--- a/app/models/concerns/setting_helper.rb
+++ b/app/models/concerns/setting_helper.rb
@@ -18,7 +18,8 @@ module SettingHelper
       {
         member: I18n.t('settings.preset_role.member', default: 'Member'),
         developer: I18n.t('settings.preset_role.developer', default: 'Developer'),
-        admin: I18n.t('settings.preset_role.admin', default: 'Admin')
+        admin: I18n.t('settings.preset_role.admin', default: 'Admin'),
+        guest: I18n.t('settings.preset_role.guest', default: 'Guest')
       }
     end
 

--- a/app/models/concerns/user_roles.rb
+++ b/app/models/concerns/user_roles.rb
@@ -7,6 +7,7 @@ module UserRoles
     scope :admins, -> { where(role: :admin) }
     scope :developers, -> { where(role: :developer) }
     scope :members, -> { where(role: :member) }
+    scope :guests, -> { where(role: :guest) }
   end
 
   def manage?(app: nil)
@@ -29,6 +30,14 @@ module UserRoles
     update!(role: :member)
   end
 
+  def grant_guest!
+    update!(role: :guest)
+  end
+
+  def revoke_guest!
+    update!(role: :member)
+  end
+
   def roles?(value)
     roles.where(role: value.to_sym).exists?
   end
@@ -43,6 +52,8 @@ module UserRoles
             :admin
           elsif developer?
             :developer
+          elsif guest?
+            :guest
           else
             :member
           end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -33,7 +33,7 @@ class Setting < RailsSettings::Base
   scope :presets do
     field :preset_schemes, default: builtin_schemes, type: :array, display: true,
           validates: { json: { format: :array } }
-    field :preset_role, default: 'member', type: :string, display: true,
+    field :preset_role, default: (ENV['ZEALOT_DEFAULT_USER_ROLE'] || 'member'), type: :string, display: true,
           validates: { presence: true, inclusion: { in: builtin_roles.keys.map(&:to_s) } }
     field :per_page, default: ENV.fetch('ZEALOT_PER_PAGE', '25').to_i, type: :integer, display: true,
           validates: { presence: true, numericality: { only_integer: true } }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,7 @@ class User < ApplicationRecord
          :validatable, :recoverable, :lockable, :magic_link_authenticatable, 
          :omniauthable, omniauth_providers: %i[feishu gitlab google_oauth2 ldap openid_connect github gitea].freeze
 
-  enum :role, %i[member developer admin]
+  enum :role, %i[member developer admin guest]
   enum :locale, enum_roles
   enum :appearance, enum_appearances
   enum :timezone, enum_timezones

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -40,7 +40,7 @@ class ApplicationPolicy
     Pundit.policy_scope!(user, record.class)
   end
 
-  delegate :admin?, :developer?, :manage?, :member?, to: :user, allow_nil: true
+  delegate :admin?, :developer?, :manage?, :member?, :guest?, to: :user, allow_nil: true
 
   class Scope
     attr_reader :user, :scope

--- a/app/policies/release_policy.rb
+++ b/app/policies/release_policy.rb
@@ -6,6 +6,10 @@ class ReleasePolicy < ApplicationPolicy
     true
   end
 
+  def download?
+    !guest?
+  end
+
   def new?
     any_manage?
   end

--- a/app/views/releases/body/_install_app.html.slim
+++ b/app/views/releases/body/_install_app.html.slim
@@ -9,23 +9,28 @@
   - unless release.app.archived
     .action-buttons class="flex gap-2 my-3" data-release-download-target="buttons"
       - if release.file?
-        - if release.platform == 'iOS'
-          - if release.cert_expired?
-            button class="d-btn d-btn-lg d-btn-secondary d-btn-disabled"
-              i.fa-solid.fa-certificate
-              = t('releases.show.cert_expired')
-          - else
-            button[
-              class="d-btn d-btn-lg d-btn-success hidden"
-              data-action="release-download#install"
-              data-release-download-target="installButton"
-            ]
-              i.fa-solid.fa-download
-              = t('releases.show.install')
+        - if current_user&.guest?
+          button class="d-btn d-btn-lg d-btn-secondary d-btn-disabled"
+            i.fa-solid.fa-lock
+            = t('releases.show.no_permission_to_download')
+        - else
+          - if release.platform == 'iOS'
+            - if release.cert_expired?
+              button class="d-btn d-btn-lg d-btn-secondary d-btn-disabled"
+                i.fa-solid.fa-certificate
+                = t('releases.show.cert_expired')
+            - else
+              button[
+                class="d-btn d-btn-lg d-btn-success hidden"
+                data-action="release-download#install"
+                data-release-download-target="installButton"
+              ]
+                i.fa-solid.fa-download
+                = t('releases.show.install')
 
-        = button_link_to t('releases.show.download'), release.download_url, 'hard-drive', \
-          class: 'd-btn d-btn-lg d-btn-success', target: '_blank', \
-          data: { release_download_target: 'downloadButton' }
+          = button_link_to t('releases.show.download'), release.download_url, 'hard-drive', \
+            class: 'd-btn d-btn-lg d-btn-success', target: '_blank', \
+            data: { release_download_target: 'downloadButton' }
       - else
         button class="d-btn d-btn-lg d-btn-secondary d-btn-disabled"
           i.fa-solid.fa-ghost

--- a/config/locales/zealot/en.yml
+++ b/config/locales/zealot/en.yml
@@ -489,6 +489,7 @@ en:
       installed: Re-Install
       cert_expired: Certificate expired
       missing_file: Missing file
+      no_permission_to_download: No permission to download
       more: More builds
       cannot_install_cause_of_certificate_expired: Why can not install app with expired certificate?
       cannot_install_or_untrusted_enterprise_developer: Occurred "Untrusted Enterprise Developer" or app failed to install?
@@ -530,6 +531,7 @@ en:
         deleted_programly: Maybe clean up by enabled auto clean job.
         not_found_really: Not found this build.
         invalid_password: Invalid password
+        no_permission_to_download: You do not have permission to download this release
         bundle_id_not_matched: "Bundle id or package name not matched between release %{got} and rule %{expect}"
   debug_files:
     title: Debug files
@@ -877,6 +879,7 @@ en:
       member: Member
       developer: Developer
       admin: Admin
+      guest: Guest
     site_locale:
       zh-CN: Simplified Chinese
       en: English

--- a/config/locales/zealot/zh-CN.yml
+++ b/config/locales/zealot/zh-CN.yml
@@ -483,6 +483,7 @@ zh-CN:
       installed: 重新安装
       cert_expired: 证书过期无法安装
       missing_file: 应用文件遗失
+      no_permission_to_download: 无下载权限
       more: 更多上传
       cannot_install_cause_of_certificate_expired: 签名证书已过期，为什么无法安装？
       cannot_install_or_untrusted_enterprise_developer: 应用已安装到桌面，安装失败或遇到 "未受信任的企业级开发者" 错误点击这里
@@ -522,6 +523,7 @@ zh-CN:
         deleted_programly: 系统开启了清理老版本功能而当前版本属于历史老版本被清理掉
         not_found_really: 您访问的应用版本真的不存在
         invalid_password: 密码错误，请重新输入
+        no_permission_to_download: 您没有权限下载此版本
         bundle_id_not_matched: "应用的包名 %{got} 和约束的包名 %{expect} 无法匹配"
         upload_to_archived_app: "应用 %{app} 已归档，无法上传新的版本。"
   debug_files:
@@ -854,6 +856,7 @@ zh-CN:
       member: 用户
       developer: 开发者
       admin: 管理员
+      guest: 访客
     site_locale:
       zh-CN: 简体中文
       en: 英文

--- a/spec/controllers/download/releases_controller_spec.rb
+++ b/spec/controllers/download/releases_controller_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Download::ReleasesController, type: :controller do
+  include Devise::Test::ControllerHelpers
+
+  let(:channel) { instance_double(Channel, to_param: 'abc12') }
+  let(:release) { instance_double(Release, id: 1, to_param: '1', channel: channel, download_url: '/dl') }
+
+  before do
+    allow(Release).to receive(:find).with('1').and_return(release)
+  end
+
+  describe 'GET #show' do
+    context 'when signed in as guest' do
+      let(:guest) { create(:user, :guest) }
+
+      before { sign_in guest }
+
+      it 'redirects to the release page' do
+        get :show, params: { id: 1 }
+        expect(response).to redirect_to(channel_release_path(channel, release))
+      end
+
+      it 'sets a no-permission alert' do
+        get :show, params: { id: 1 }
+        expect(flash[:alert]).to eq(I18n.t('releases.messages.errors.no_permission_to_download'))
+      end
+    end
+
+    context 'when not signed in' do
+      before do
+        allow(release).to receive(:cookie_password_matched?).and_return(false)
+      end
+
+      it 'does not set a no-permission alert' do
+        get :show, params: { id: 1 }
+        expect(flash[:alert]).to be_nil
+      end
+    end
+  end
+
+  describe 'GET #download' do
+    context 'when signed in as guest' do
+      let(:guest) { create(:user, :guest) }
+
+      before { sign_in guest }
+
+      it 'redirects to the release page' do
+        get :download, params: { id: 1, filename: 'app.ipa' }
+        expect(response).to redirect_to(channel_release_path(channel, release))
+      end
+
+      it 'sets a no-permission alert' do
+        get :download, params: { id: 1, filename: 'app.ipa' }
+        expect(flash[:alert]).to eq(I18n.t('releases.messages.errors.no_permission_to_download'))
+      end
+    end
+
+    context 'when signed in as member' do
+      let(:member) { create(:user, :member) }
+
+      before do
+        sign_in member
+        allow(release).to receive(:file).and_return(double(size: 1024, path: '/tmp/app.ipa'))
+        allow(release).to receive(:download_filename).and_return('app.ipa')
+        allow(channel).to receive(:perform_web_hook)
+        allow(File).to receive(:file?).and_return(true)
+        allow(File).to receive(:readable?).and_return(true)
+      end
+
+      it 'does not set a no-permission alert' do
+        get :download, params: { id: 1, filename: 'app.ipa' }
+        expect(flash[:alert]).to be_nil
+      end
+    end
+  end
+end

--- a/spec/controllers/download/releases_controller_spec.rb
+++ b/spec/controllers/download/releases_controller_spec.rb
@@ -16,7 +16,10 @@ RSpec.describe Download::ReleasesController, type: :controller do
     context 'when signed in as guest' do
       let(:guest) { create(:user, :guest) }
 
-      before { sign_in guest }
+      before do
+        sign_in guest
+        allow(controller).to receive(:authorize).and_raise(Pundit::NotAuthorizedError)
+      end
 
       it 'redirects to the release page' do
         get :show, params: { id: 1 }
@@ -31,6 +34,7 @@ RSpec.describe Download::ReleasesController, type: :controller do
 
     context 'when not signed in' do
       before do
+        allow(controller).to receive(:authorize).and_return(true)
         allow(release).to receive(:cookie_password_matched?).and_return(false)
       end
 
@@ -45,7 +49,10 @@ RSpec.describe Download::ReleasesController, type: :controller do
     context 'when signed in as guest' do
       let(:guest) { create(:user, :guest) }
 
-      before { sign_in guest }
+      before do
+        sign_in guest
+        allow(controller).to receive(:authorize).and_raise(Pundit::NotAuthorizedError)
+      end
 
       it 'redirects to the release page' do
         get :download, params: { id: 1, filename: 'app.ipa' }
@@ -63,6 +70,7 @@ RSpec.describe Download::ReleasesController, type: :controller do
 
       before do
         sign_in member
+        allow(controller).to receive(:authorize).and_return(true)
         allow(release).to receive(:file).and_return(double(size: 1024, path: '/tmp/app.ipa'))
         allow(release).to receive(:download_filename).and_return('app.ipa')
         allow(channel).to receive(:perform_web_hook)

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -2,6 +2,26 @@
 
 FactoryBot.define do
   factory :user do
+    sequence(:username) { |n| "user#{n}" }
+    sequence(:email) { |n| "user#{n}@example.com" }
+    password { 'password123' }
+    confirmed_at { Time.current }
     token { Digest::MD5.hexdigest(SecureRandom.uuid) }
+
+    trait :guest do
+      role { :guest }
+    end
+
+    trait :member do
+      role { :member }
+    end
+
+    trait :developer do
+      role { :developer }
+    end
+
+    trait :admin do
+      role { :admin }
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  describe 'guest role' do
+    subject(:user) { build(:user, :guest) }
+
+    it { is_expected.to be_guest }
+    it { is_expected.not_to be_member }
+    it { is_expected.not_to be_developer }
+    it { is_expected.not_to be_admin }
+
+    it 'cannot manage' do
+      expect(user.manage?).to be false
+    end
+
+    it 'returns guest role name' do
+      expect(user.role_name).to eq(Setting.builtin_roles[:guest])
+    end
+  end
+
+  describe '#grant_guest!' do
+    let(:user) { create(:user, :member) }
+
+    it 'changes role to guest' do
+      user.grant_guest!
+      expect(user.reload).to be_guest
+    end
+  end
+
+  describe '#revoke_guest!' do
+    let(:user) { create(:user, :guest) }
+
+    it 'changes role back to member' do
+      user.revoke_guest!
+      expect(user.reload).to be_member
+    end
+  end
+
+  describe 'default role on registration' do
+    context 'when preset_role is guest' do
+      before { allow(Setting).to receive(:preset_role).and_return('guest') }
+
+      it 'assigns guest role to new users' do
+        expect(build(:user)).to be_guest
+      end
+    end
+
+    context 'when preset_role is member' do
+      before { allow(Setting).to receive(:preset_role).and_return('member') }
+
+      it 'assigns member role to new users' do
+        expect(build(:user)).to be_member
+      end
+    end
+  end
+end


### PR DESCRIPTION
  ## Summary      
            
  - Add `guest` as a new user role with read-only access (no download permission)                       
  - Guest users see a disabled lock button on release pages; both `show` and `download` actions are     
  protected server-side                                                                                 
  - Default role for new users is configurable via `Setting.preset_role` (admin UI) or                  
  `ZEALOT_DEFAULT_USER_ROLE` env variable                                             
                                                                                                        
  ## Changes      
                                                                                                        
  - `User` model: add `guest` to role enum (integer value 3, backward-compatible)
  - `Download::ReleasesController`: block guest access on both `show` and `download` actions            
  - `Setting.preset_role`: support `ZEALOT_DEFAULT_USER_ROLE` env var for container deployments
  - `UserRoles`: add `grant_guest!` / `revoke_guest!` methods, `:guests` scope, `guest?` in `role_name` 
  - `ApplicationPolicy`: delegate `guest?` to user                                                      
  - i18n: add translations for guest role and no-permission messages (en + zh-CN)                       
                                                                                                        
  ## Test plan                                                                                          
                                                                                                        
  - [ ] Register a new user → verify role is `guest` when `preset_role` is set to guest                 
  - [ ] As guest, visit a release page → download button is disabled (lock icon)                        
  - [ ] As guest, directly access download URL → redirected with alert          
  - [ ] As member/developer/admin, download works normally                                              
  - [ ] Admin panel: role selector includes Guest option                                                
  - [ ] RSpec: `spec/models/user_spec.rb` and `spec/controllers/download/releases_controller_spec.rb`  