### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/issue_translator.yml
+++ b/.github/workflows/issue_translator.yml
@@ -5,6 +5,10 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/tryzealot/zealot/security/code-scanning/2](https://github.com/tryzealot/zealot/security/code-scanning/2)

Add an explicit `permissions` block in `.github/workflows/issue_translator.yml`.  
Best single fix without changing existing functionality is to define minimal workflow-level permissions that match this workflow’s purpose (handling issues/comments). A safe baseline here is:

- `contents: read` (common minimal read access)
- `issues: write` (needed to comment/update issues via the action)

Place this block at the workflow root (after `on:` section and before `jobs:`), so it applies to all jobs unless overridden.

No imports, methods, or dependencies are needed—just YAML changes in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
