### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sync_readme.yml
+++ b/.github/workflows/sync_readme.yml
@@ -1,4 +1,6 @@
 name: Sync README to Organization
+permissions:
+  contents: read
 on:
   push:
     paths:


### PR DESCRIPTION
Potential fix for [https://github.com/tryzealot/zealot/security/code-scanning/18](https://github.com/tryzealot/zealot/security/code-scanning/18)

Add an explicit `permissions` block to `.github/workflows/sync_readme.yml` at the workflow root level (right after `name` is the clearest placement), granting only the minimum needed scope:

- `contents: read`

This applies to all jobs unless overridden and satisfies CodeQL’s requirement while preserving existing behavior. No imports, methods, or dependencies are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
