### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test_docker_build.yml
+++ b/.github/workflows/test_docker_build.yml
@@ -11,6 +11,9 @@ on:
       - "*.yaml"
       - "*.yml"
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/tryzealot/zealot/security/code-scanning/19](https://github.com/tryzealot/zealot/security/code-scanning/19)

Add an explicit `permissions` block to the workflow so the token is least-privileged and behavior is stable across repositories/org defaults.  
Best fix here: define workflow-level permissions immediately after the `on:` block (or after `name:`/`on:` section and before `jobs:`), with at least:

- `contents: read`

This preserves existing functionality for checkout/build in the shown workflow while satisfying the CodeQL requirement and documenting intended access.

File to change:
- `.github/workflows/test_docker_build.yml`

Region to change:
- Insert `permissions:` before `jobs:`.

No imports, methods, or external definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
